### PR TITLE
Enable https protocol for TestHttpsAsyncTimeout, so timeout will be tested for real

### DIFF
--- a/httpcore-nio/src/test/java/org/apache/http/nio/integration/TestHttpsAsyncTimeout.java
+++ b/httpcore-nio/src/test/java/org/apache/http/nio/integration/TestHttpsAsyncTimeout.java
@@ -53,6 +53,10 @@ public class TestHttpsAsyncTimeout extends HttpCoreNIOTestBase {
 
     private ServerSocket serverSocket;
 
+    public TestHttpsAsyncTimeout() {
+        super(ProtocolScheme.https);
+    }
+
     @Before
     public void setUp() throws Exception {
         initClient();


### PR DESCRIPTION
Without this test finishes immediately with IOException: SSL not supported, so not real handshake testing performed