### PR TITLE
HTTPCLIENT-1693 client request trailers

### DIFF
--- a/httpcore-ab/src/main/java/org/apache/http/benchmark/BenchmarkConnection.java
+++ b/httpcore-ab/src/main/java/org/apache/http/benchmark/BenchmarkConnection.java
@@ -28,6 +28,8 @@ package org.apache.http.benchmark;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Map;
+import java.util.concurrent.Callable;
 
 import org.apache.http.impl.DefaultBHttpClientConnection;
 import org.apache.http.io.SessionInputBuffer;
@@ -43,8 +45,10 @@ class BenchmarkConnection extends DefaultBHttpClientConnection {
     }
 
     @Override
-    protected OutputStream createContentOutputStream(final long len, final SessionOutputBuffer outbuffer) {
-        return new CountingOutputStream(super.createContentOutputStream(len, outbuffer), this.stats);
+    protected OutputStream createContentOutputStream(final long len,
+                                                     final SessionOutputBuffer outbuffer,
+                                                     final Map<String, Callable<String>> trailers) {
+        return new CountingOutputStream(super.createContentOutputStream(len, outbuffer, trailers), this.stats);
     }
 
     @Override

--- a/httpcore/src/main/java/org/apache/http/HttpMessage.java
+++ b/httpcore/src/main/java/org/apache/http/HttpMessage.java
@@ -27,6 +27,9 @@
 
 package org.apache.http;
 
+import java.util.Map;
+import java.util.concurrent.Callable;
+
 /**
  * HTTP messages consist of requests from client to server and responses
  * from server to client.
@@ -116,4 +119,5 @@ public interface HttpMessage<T> extends MessageHead {
      */
     void setEntity(T entity);
 
+    void setTrailers(Map<String, Callable<String>> trailers);
 }

--- a/httpcore/src/main/java/org/apache/http/MessageHead.java
+++ b/httpcore/src/main/java/org/apache/http/MessageHead.java
@@ -28,6 +28,8 @@
 package org.apache.http;
 
 import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.Callable;
 
 /**
  * HTTP messages head consisting of multiple message headers.
@@ -115,4 +117,5 @@ public interface MessageHead {
      */
     Iterator<Header> headerIterator(String name);
 
+    Map<String,Callable<String>> getTrailers();
 }

--- a/httpcore/src/main/java/org/apache/http/impl/BHttpConnectionBase.java
+++ b/httpcore/src/main/java/org/apache/http/impl/BHttpConnectionBase.java
@@ -36,6 +36,8 @@ import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
+import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.http.BHttpConnection;
@@ -138,11 +140,12 @@ class BHttpConnectionBase implements BHttpConnection {
 
     protected OutputStream createContentOutputStream(
             final long len,
-            final SessionOutputBuffer outbuffer) {
+            final SessionOutputBuffer outbuffer,
+            final Map<String, Callable<String>> trailers) {
         if (len >= 0) {
             return new ContentLengthOutputStream(outbuffer, len);
         } else if (len == ContentLengthStrategy.CHUNKED) {
-            return new ChunkedOutputStream(2048, outbuffer);
+            return new ChunkedOutputStream(2048, outbuffer, trailers);
         } else {
             return new IdentityOutputStream(outbuffer);
         }

--- a/httpcore/src/main/java/org/apache/http/impl/DefaultBHttpServerConnection.java
+++ b/httpcore/src/main/java/org/apache/http/impl/DefaultBHttpServerConnection.java
@@ -32,6 +32,8 @@ import java.io.OutputStream;
 import java.net.Socket;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
+import java.util.Collections;
+import java.util.concurrent.Callable;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpException;
@@ -174,7 +176,8 @@ public class DefaultBHttpServerConnection extends BHttpConnectionBase
             return;
         }
         final long len = this.outgoingContentStrategy.determineLength(response);
-        final OutputStream outstream = createContentOutputStream(len, this.outbuffer);
+        final OutputStream outstream = createContentOutputStream(len, this.outbuffer,
+                Collections.<String, Callable<String>>emptyMap());
         entity.writeTo(outstream);
         outstream.close();
     }

--- a/httpcore/src/main/java/org/apache/http/impl/entity/DefaultContentLengthStrategy.java
+++ b/httpcore/src/main/java/org/apache/http/impl/entity/DefaultContentLengthStrategy.java
@@ -67,7 +67,7 @@ public class DefaultContentLengthStrategy implements ContentLengthStrategy {
         // it is either missing or has the single value "chunked". So we
         // treat it as a single-valued header here.
         final Header transferEncodingHeader = message.getFirstHeader(HttpHeaders.TRANSFER_ENCODING);
-        if (transferEncodingHeader != null) {
+        if (transferEncodingHeader != null || !message.getTrailers().isEmpty()) {
             final String s = transferEncodingHeader.getValue();
             if (HeaderElements.CHUNKED_ENCODING.equalsIgnoreCase(s)) {
                 return CHUNKED;

--- a/httpcore/src/main/java/org/apache/http/message/HeaderGroup.java
+++ b/httpcore/src/main/java/org/apache/http/message/HeaderGroup.java
@@ -33,6 +33,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.Callable;
 
 import org.apache.http.Header;
 import org.apache.http.annotation.NotThreadSafe;
@@ -55,6 +57,8 @@ public class HeaderGroup implements Serializable {
 
     /** The list of headers for this group, in the order in which they were added */
     private final List<Header> headers;
+
+    private Map<String, Callable<String>> trailers = Collections.emptyMap();
 
     /**
      * Constructor for HeaderGroup.
@@ -336,4 +340,14 @@ public class HeaderGroup implements Serializable {
         return this.headers.toString();
     }
 
+    public void setTrailers(final Map<String, Callable<String>> trailers) {
+        if (trailers == null) {
+            throw new NullPointerException();
+        }
+        this.trailers = trailers;
+    }
+
+    public Map<String, Callable<String>> getTrailers() {
+        return trailers;
+    }
 }


### PR DESCRIPTION
This patch implements [HTTP 1.1 trailers](https://tools.ietf.org/html/rfc7230#section-4.1.2) and allows a   client to send some headers after chunked body.

For example client use streaming content (proxy) and cannot send data  like hash code of transferred content in traditional headers.

I opened [ticket](https://issues.apache.org/jira/browse/HTTPCLIENT-1693).

Here is an example of usage without httpclient. I encountered problems because httpclient and httpcore trunks are not compatible. So I found example in httpcore and modified it.
Also there is a new test case for ChunkeOutputStream.

```
        HttpProcessor httpproc = HttpProcessorBuilder.create()
                .add(new RequestContent())
                .add(new RequestTargetHost())
                .add(new RequestConnControl())
                .add(new RequestUserAgent("Test/1.1"))
                .build();
        HttpRequestExecutor httpexecutor = new HttpRequestExecutor();
        HttpCoreContext coreContext = HttpCoreContext.create();
        HttpHost host = new HttpHost("localhost", 8080);
        coreContext.setTargetHost(host);
        DefaultBHttpClientConnection conn = new DefaultBHttpClientConnection(8 * 1024);
        InputStreamEntity requestBody =
                new InputStreamEntity(
                        new ByteArrayInputStream(
                                "This is the third test request (will be chunked)"
                                        .getBytes(Consts.UTF_8)),
                        ContentType.APPLICATION_OCTET_STREAM);
        requestBody.setChunked(true);
        Socket socket = new Socket(host.getHostName(), host.getPort());
        conn.bind(socket);
        BasicHttpRequest request = new BasicHttpRequest("POST", "/");
        request.setEntity(requestBody);
        Map<String, Callable<String>> m = new HashMap<>();
        m.put("t1", new Callable<String>() {
            public String call() throws Exception {
                return "Hello world";
            }
        });
        request.setTrailers(m);
        httpexecutor.preProcess(request, httpproc, coreContext);
        HttpResponse response = httpexecutor.execute(request, conn, coreContext);
        httpexecutor.postProcess(response, httpproc, coreContext);

        System.out.println("<< Response: " + response.getStatusLine());
        System.out.println(EntityUtils.toString(response.getEntity()));
        System.out.println("==============");
        conn.close();
```
