### PR TITLE
 HTTPCORE-412 Trailers as headers in entity

### DIFF
--- a/httpcore-nio/src/examples/org/apache/http/examples/nio/NHttpClientPostWithTrailers.java
+++ b/httpcore-nio/src/examples/org/apache/http/examples/nio/NHttpClientPostWithTrailers.java
@@ -1,0 +1,148 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.http.examples.nio;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.util.concurrent.CountDownLatch;
+
+import org.apache.http.ConstTrailerSupplier;
+import org.apache.http.Consts;
+import org.apache.http.Header;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.config.ConnectionConfig;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.impl.nio.DefaultHttpClientIODispatch;
+import org.apache.http.impl.nio.pool.BasicNIOConnPool;
+import org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicHttpRequest;
+import org.apache.http.nio.protocol.BasicAsyncRequestProducer;
+import org.apache.http.nio.protocol.BasicAsyncResponseConsumer;
+import org.apache.http.nio.protocol.HttpAsyncRequestExecutor;
+import org.apache.http.nio.protocol.HttpAsyncRequester;
+import org.apache.http.nio.reactor.ConnectingIOReactor;
+import org.apache.http.nio.reactor.IOEventDispatch;
+import org.apache.http.protocol.HttpCoreContext;
+import org.apache.http.protocol.HttpProcessor;
+import org.apache.http.protocol.HttpProcessorBuilder;
+import org.apache.http.protocol.RequestConnControl;
+import org.apache.http.protocol.RequestContent;
+import org.apache.http.protocol.RequestExpectContinue;
+import org.apache.http.protocol.RequestTargetHost;
+import org.apache.http.protocol.RequestUserAgent;
+
+/**
+ * Minimal asynchronous HTTP/1.1 client sending POST request with trailers.
+ */
+public class NHttpClient {
+    public static void main(String[] args) throws Exception {
+        // Create HTTP protocol processing chain
+        HttpProcessor httpproc = HttpProcessorBuilder.create()
+                // Use standard client-side protocol interceptors
+                .add(new RequestContent())
+                .add(new RequestTargetHost())
+                .add(new RequestConnControl())
+                .add(new RequestUserAgent("Test/1.1"))
+                .add(new RequestExpectContinue()).build();
+        // Create client-side HTTP protocol handler
+        HttpAsyncRequestExecutor protocolHandler = new HttpAsyncRequestExecutor();
+        // Create client-side I/O event dispatch
+        final IOEventDispatch ioEventDispatch = new DefaultHttpClientIODispatch(protocolHandler,
+                ConnectionConfig.DEFAULT);
+        // Create client-side I/O reactor
+        final ConnectingIOReactor ioReactor = new DefaultConnectingIOReactor();
+        // Create HTTP connection pool
+        BasicNIOConnPool pool = new BasicNIOConnPool(ioReactor, ConnectionConfig.DEFAULT);
+        // Limit total number of connections to just two
+        pool.setDefaultMaxPerRoute(2);
+        pool.setMaxTotal(2);
+        // Run the I/O reactor in a separate thread
+        Thread t = new Thread(new Runnable() {
+
+            @Override
+            public void run() {
+                try {
+                    // Ready to go!
+                    ioReactor.execute(ioEventDispatch);
+                } catch (InterruptedIOException ex) {
+                    System.err.println("Interrupted");
+                } catch (IOException e) {
+                    System.err.println("I/O error: " + e.getMessage());
+                }
+                System.out.println("Shutdown");
+            }
+
+        });
+        // Start the client thread
+        t.start();
+        // Create HTTP requester
+        HttpAsyncRequester requester = new HttpAsyncRequester(httpproc);
+        final HttpHost target = new HttpHost("localhost", 8080, "http");
+        final CountDownLatch latch = new CountDownLatch(1);
+        InputStreamEntity requestBody =
+                new InputStreamEntity(
+                        new ByteArrayInputStream(
+                                "This is the third test request (will be chunked)"
+                                        .getBytes(Consts.UTF_8)),
+                        ContentType.APPLICATION_OCTET_STREAM);
+        requestBody.setChunked(true);
+        requestBody.setTrailers(new ConstTrailerSupplier(
+                new Header[] { new BasicHeader("t1","Hello world") }));
+        BasicHttpRequest request = new BasicHttpRequest("POST", "/");
+        request.setEntity(requestBody);
+        HttpCoreContext coreContext = HttpCoreContext.create();
+        requester.execute(
+                new BasicAsyncRequestProducer(target, request),
+                new BasicAsyncResponseConsumer(),
+                pool,
+                coreContext,
+                // Handle HTTP response from a callback
+                new FutureCallback<HttpResponse>() {
+                    public void completed(final HttpResponse response) {
+                        latch.countDown();
+                        System.out.println(target + "->" + response.getStatusLine());
+                    }
+                    public void failed(final Exception ex) {
+                        latch.countDown();
+                        System.out.println(target + "->" + ex);
+                    }
+                    public void cancelled() {
+                        latch.countDown();
+                        System.out.println(target + " cancelled");
+                    }
+                });
+        latch.await();
+        System.out.println("Shutting down I/O reactor");
+        ioReactor.shutdown();
+        System.out.println("Done");
+    }
+}

--- a/httpcore-nio/src/main/java/org/apache/http/impl/nio/DefaultNHttpClientConnection.java
+++ b/httpcore-nio/src/main/java/org/apache/http/impl/nio/DefaultNHttpClientConnection.java
@@ -41,6 +41,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.annotation.NotThreadSafe;
 import org.apache.http.config.MessageConstraints;
 import org.apache.http.entity.ContentLengthStrategy;
+import org.apache.http.impl.entity.CheckUndefinedDecorator;
 import org.apache.http.impl.entity.DefaultContentLengthStrategy;
 import org.apache.http.impl.nio.codecs.DefaultHttpRequestWriterFactory;
 import org.apache.http.impl.nio.codecs.DefaultHttpResponseParserFactory;
@@ -112,8 +113,10 @@ public class DefaultNHttpClientConnection
             DefaultHttpResponseParserFactory.INSTANCE).create(constraints);
         this.incomingContentStrategy = incomingContentStrategy != null ? incomingContentStrategy :
                 DefaultContentLengthStrategy.INSTANCE;
-        this.outgoingContentStrategy = outgoingContentStrategy != null ? outgoingContentStrategy :
-                DefaultContentLengthStrategy.INSTANCE;
+        this.outgoingContentStrategy = new CheckUndefinedDecorator(
+                outgoingContentStrategy != null
+                        ? outgoingContentStrategy
+                        : DefaultContentLengthStrategy.INSTANCE);
     }
 
     /**

--- a/httpcore-nio/src/main/java/org/apache/http/impl/nio/DefaultNHttpClientConnection.java
+++ b/httpcore-nio/src/main/java/org/apache/http/impl/nio/DefaultNHttpClientConnection.java
@@ -276,7 +276,8 @@ public class DefaultNHttpClientConnection
                     len,
                     this.session.channel(),
                     this.outbuf,
-                    this.outTransportMetrics);
+                    this.outTransportMetrics,
+                    request.getEntity().getTrailers());
         }
         this.connMetrics.incrementRequestCount();
         this.session.setEvent(EventMask.WRITE);

--- a/httpcore-nio/src/main/java/org/apache/http/impl/nio/DefaultNHttpClientConnection.java
+++ b/httpcore-nio/src/main/java/org/apache/http/impl/nio/DefaultNHttpClientConnection.java
@@ -27,6 +27,8 @@
 
 package org.apache.http.impl.nio;
 
+import static org.apache.http.impl.entity.DefaultContentLengthStrategy.determineLength;
+
 import java.io.IOException;
 import java.nio.channels.SelectionKey;
 import java.nio.charset.CharsetDecoder;
@@ -36,7 +38,6 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
-import org.apache.http.LengthRequiredException;
 import org.apache.http.annotation.NotThreadSafe;
 import org.apache.http.config.MessageConstraints;
 import org.apache.http.entity.ContentLengthStrategy;
@@ -268,12 +269,8 @@ public class DefaultNHttpClientConnection
 
         if (request.getEntity() != null) {
             this.request = request;
-            final long len = this.outgoingContentStrategy.determineLength(request);
-            if (len == ContentLengthStrategy.UNDEFINED) {
-                throw new LengthRequiredException("Length required");
-            }
             this.contentEncoder = createContentEncoder(
-                    len,
+                    determineLength(outgoingContentStrategy, request, request.getEntity()),
                     this.session.channel(),
                     this.outbuf,
                     this.outTransportMetrics,

--- a/httpcore-nio/src/main/java/org/apache/http/impl/nio/DefaultNHttpServerConnection.java
+++ b/httpcore-nio/src/main/java/org/apache/http/impl/nio/DefaultNHttpServerConnection.java
@@ -32,6 +32,7 @@ import java.nio.channels.SelectionKey;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
 
+import org.apache.http.EmptyTrailerSupplier;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;
@@ -276,7 +277,8 @@ public class DefaultNHttpServerConnection
                         len,
                         this.session.channel(),
                         this.outbuf,
-                        this.outTransportMetrics);
+                        this.outTransportMetrics,
+                        EmptyTrailerSupplier.instance);
             }
         }
 

--- a/httpcore-nio/src/main/java/org/apache/http/impl/nio/DefaultNHttpServerConnection.java
+++ b/httpcore-nio/src/main/java/org/apache/http/impl/nio/DefaultNHttpServerConnection.java
@@ -27,12 +27,13 @@
 
 package org.apache.http.impl.nio;
 
+import static org.apache.http.impl.entity.DefaultContentLengthStrategy.determineLength;
+
 import java.io.IOException;
 import java.nio.channels.SelectionKey;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
 
-import org.apache.http.EmptyTrailerSupplier;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;
@@ -272,13 +273,13 @@ public class DefaultNHttpServerConnection
             this.connMetrics.incrementResponseCount();
             if (response.getEntity() != null) {
                 this.response = response;
-                final long len = this.outgoingContentStrategy.determineLength(response);
                 this.contentEncoder = createContentEncoder(
-                        len,
+                        determineLength(outgoingContentStrategy, response,
+                                response.getEntity()),
                         this.session.channel(),
                         this.outbuf,
                         this.outTransportMetrics,
-                        EmptyTrailerSupplier.instance);
+                        response.getEntity().getTrailers());
             }
         }
 

--- a/httpcore-nio/src/main/java/org/apache/http/impl/nio/NHttpConnectionBase.java
+++ b/httpcore-nio/src/main/java/org/apache/http/impl/nio/NHttpConnectionBase.java
@@ -43,6 +43,7 @@ import org.apache.http.HttpHeaders;
 import org.apache.http.HttpMessage;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
+import org.apache.http.TrailerSupplier;
 import org.apache.http.config.MessageConstraints;
 import org.apache.http.entity.ContentLengthStrategy;
 import org.apache.http.impl.HttpConnectionMetricsImpl;
@@ -225,12 +226,13 @@ class NHttpConnectionBase implements NHttpConnection, SessionBufferStatus, Socke
     /**
      * Factory method for {@link ContentEncoder} instances.
      *
-     * @param len content length, if known, {@link ContentLengthStrategy#CHUNKED} or
-     *   {@link ContentLengthStrategy#UNDEFINED}, if unknown.
+     * @param len content length, if known, {@link org.apache.http.entity.ContentLengthStrategy#CHUNKED} or
+     *   {@link org.apache.http.entity.ContentLengthStrategy#UNDEFINED}, if unknown.
      * @param channel the session channel.
      * @param buffer the session buffer.
      * @param metrics transport metrics.
      *
+     * @param trailers
      * @return content encoder.
      *
      * @since 4.1
@@ -239,11 +241,13 @@ class NHttpConnectionBase implements NHttpConnection, SessionBufferStatus, Socke
             final long len,
             final WritableByteChannel channel,
             final SessionOutputBuffer buffer,
-            final HttpTransportMetricsImpl metrics) {
+            final HttpTransportMetricsImpl metrics,
+            final TrailerSupplier trailers) {
         if (len >= 0) {
             return new LengthDelimitedEncoder(channel, buffer, metrics, len, this.fragmentSizeHint);
         } else if (len == ContentLengthStrategy.CHUNKED) {
-            return new ChunkEncoder(channel, buffer, metrics, this.fragmentSizeHint);
+            return new ChunkEncoder(channel, buffer, metrics,
+                    this.fragmentSizeHint, trailers);
         } else {
             return new IdentityEncoder(channel, buffer, metrics, this.fragmentSizeHint);
         }

--- a/httpcore-nio/src/test/java/org/apache/http/nio/integration/TestTruncatedChunks.java
+++ b/httpcore-nio/src/test/java/org/apache/http/nio/integration/TestTruncatedChunks.java
@@ -40,6 +40,7 @@ import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.MalformedChunkCodingException;
+import org.apache.http.TrailerSupplier;
 import org.apache.http.TruncatedChunkException;
 import org.apache.http.entity.ContentLengthStrategy;
 import org.apache.http.entity.ContentType;
@@ -153,11 +154,12 @@ public class TestTruncatedChunks extends HttpCoreNIOTestBase {
                         final long len,
                         final WritableByteChannel channel,
                         final SessionOutputBuffer buffer,
-                        final HttpTransportMetricsImpl metrics) {
+                        final HttpTransportMetricsImpl metrics,
+                        final TrailerSupplier trailers) {
                     if (len == ContentLengthStrategy.CHUNKED) {
                         return new BrokenChunkEncoder(channel, buffer, metrics);
                     } else {
-                        return super.createContentEncoder(len, channel, buffer, metrics);
+                        return super.createContentEncoder(len, channel, buffer, metrics, trailers);
                     }
                 }
 

--- a/httpcore/src/examples/org/apache/http/examples/ElementalHttpPostTrailers.java
+++ b/httpcore/src/examples/org/apache/http/examples/ElementalHttpPostTrailers.java
@@ -1,0 +1,100 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http.examples;
+
+import java.io.ByteArrayInputStream;
+import java.net.Socket;
+
+import org.apache.http.ConstTrailerSupplier;
+import org.apache.http.Consts;
+import org.apache.http.Header;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.impl.DefaultBHttpClientConnection;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicHttpRequest;
+import org.apache.http.protocol.HttpCoreContext;
+import org.apache.http.protocol.HttpProcessor;
+import org.apache.http.protocol.HttpProcessorBuilder;
+import org.apache.http.protocol.HttpRequestExecutor;
+import org.apache.http.protocol.RequestConnControl;
+import org.apache.http.protocol.RequestContent;
+import org.apache.http.protocol.RequestTargetHost;
+import org.apache.http.protocol.RequestUserAgent;
+import org.apache.http.util.EntityUtils;
+
+/**
+ * Elemental example for executing POST request with trailing headers
+ *
+ * <pre>{@code
+ * protected void doPost(HttpServletRequest req, HttpServletResponse resp)
+ *            throws ServletException, IOException {
+ *       // read all body first
+ *       IOUtils.copy(req.getInputStream(), resp.getOutputStream());
+ *       logger.info("t1 trailer header is [{}]", req.getHeader("t1"));
+ *   }
+ * }</pre>
+ */
+public class ElementalHttpPost {
+    public static void main(String[] args) throws Exception {
+        HttpProcessor httpproc = HttpProcessorBuilder.create()
+                .add(new RequestContent())
+                .add(new RequestTargetHost())
+                .add(new RequestConnControl())
+                .add(new RequestUserAgent("Test/1.1"))
+                .build();
+        HttpRequestExecutor httpexecutor = new HttpRequestExecutor();
+        HttpCoreContext coreContext = HttpCoreContext.create();
+        HttpHost host = new HttpHost("localhost", 8080);
+        coreContext.setTargetHost(host);
+        DefaultBHttpClientConnection conn = new DefaultBHttpClientConnection(8 * 1024);
+        InputStreamEntity requestBody =
+                new InputStreamEntity(
+                        new ByteArrayInputStream(
+                                "This is the third test request (will be chunked)"
+                                        .getBytes(Consts.UTF_8)),
+                        ContentType.APPLICATION_OCTET_STREAM);
+        requestBody.setTrailers(new ConstTrailerSupplier(
+                new Header[] { new BasicHeader("t1","Hello world") }));
+        requestBody.setChunked(true);
+        Socket socket = new Socket(host.getHostName(), host.getPort());
+        conn.bind(socket);
+        BasicHttpRequest request = new BasicHttpRequest("POST", "/");
+        request.setEntity(requestBody);
+        httpexecutor.preProcess(request, httpproc, coreContext);
+        HttpResponse response = httpexecutor.execute(request, conn, coreContext);
+        httpexecutor.postProcess(response, httpproc, coreContext);
+
+        System.out.println("<< Response: " + response.getStatusLine());
+        System.out.println(EntityUtils.toString(response.getEntity()));
+        System.out.println("==============");
+        conn.close();
+    }
+}

--- a/httpcore/src/main/java/org/apache/http/ConstTrailerSupplier.java
+++ b/httpcore/src/main/java/org/apache/http/ConstTrailerSupplier.java
@@ -24,35 +24,18 @@
  * <http://www.apache.org/>.
  *
  */
-package org.apache.http.benchmark;
 
-import java.io.InputStream;
-import java.io.OutputStream;
+package org.apache.http;
 
-import org.apache.http.TrailerSupplier;
-import org.apache.http.impl.DefaultBHttpClientConnection;
-import org.apache.http.io.SessionInputBuffer;
-import org.apache.http.io.SessionOutputBuffer;
+public class ConstTrailerSupplier implements TrailerSupplier {
+    private final Header[] values;
 
-class BenchmarkConnection extends DefaultBHttpClientConnection {
-
-    private final Stats stats;
-
-    BenchmarkConnection(final int bufsize, final Stats stats) {
-        super(bufsize);
-        this.stats = stats;
+    public ConstTrailerSupplier(final Header[] values) {
+        this.values = values;
     }
 
     @Override
-    protected OutputStream createContentOutputStream(final long len,
-                                                     final SessionOutputBuffer outbuffer,
-                                                     final TrailerSupplier trailers) {
-        return new CountingOutputStream(super.createContentOutputStream(len, outbuffer, trailers), this.stats);
+    public Header[] get() {
+        return values;
     }
-
-    @Override
-    protected InputStream createContentInputStream(final long len, final SessionInputBuffer inbuffer) {
-        return new CountingInputStream(super.createContentInputStream(len, inbuffer), this.stats);
-    }
-
 }

--- a/httpcore/src/main/java/org/apache/http/EmptyTrailerSupplier.java
+++ b/httpcore/src/main/java/org/apache/http/EmptyTrailerSupplier.java
@@ -24,35 +24,16 @@
  * <http://www.apache.org/>.
  *
  */
-package org.apache.http.benchmark;
 
-import java.io.InputStream;
-import java.io.OutputStream;
+package org.apache.http;
 
-import org.apache.http.TrailerSupplier;
-import org.apache.http.impl.DefaultBHttpClientConnection;
-import org.apache.http.io.SessionInputBuffer;
-import org.apache.http.io.SessionOutputBuffer;
+public class EmptyTrailerSupplier implements TrailerSupplier {
+    private static final Header[] EMPTY = new Header[0];
+    public static final EmptyTrailerSupplier instance = new EmptyTrailerSupplier();
 
-class BenchmarkConnection extends DefaultBHttpClientConnection {
+    private EmptyTrailerSupplier() {}
 
-    private final Stats stats;
-
-    BenchmarkConnection(final int bufsize, final Stats stats) {
-        super(bufsize);
-        this.stats = stats;
+    public Header[] get() {
+        return EMPTY;
     }
-
-    @Override
-    protected OutputStream createContentOutputStream(final long len,
-                                                     final SessionOutputBuffer outbuffer,
-                                                     final TrailerSupplier trailers) {
-        return new CountingOutputStream(super.createContentOutputStream(len, outbuffer, trailers), this.stats);
-    }
-
-    @Override
-    protected InputStream createContentInputStream(final long len, final SessionInputBuffer inbuffer) {
-        return new CountingInputStream(super.createContentInputStream(len, inbuffer), this.stats);
-    }
-
 }

--- a/httpcore/src/main/java/org/apache/http/HttpEntity.java
+++ b/httpcore/src/main/java/org/apache/http/HttpEntity.java
@@ -166,4 +166,12 @@ public interface HttpEntity {
      */
     boolean isStreaming(); // don't expect an exception here
 
+    /**
+     * Map of HTTP trailers which will be delivered to a server.
+     * Keys are used to compose HTTP trailer to declare trailers in advance.
+     * Callbacks are called only after body transferred,
+     * the values they returned are used as trailer values.
+     * @return map of trailing headers
+     */
+     TrailerSupplier getTrailers();
 }

--- a/httpcore/src/main/java/org/apache/http/TrailerSupplier.java
+++ b/httpcore/src/main/java/org/apache/http/TrailerSupplier.java
@@ -24,35 +24,14 @@
  * <http://www.apache.org/>.
  *
  */
-package org.apache.http.benchmark;
 
-import java.io.InputStream;
-import java.io.OutputStream;
+package org.apache.http;
 
-import org.apache.http.TrailerSupplier;
-import org.apache.http.impl.DefaultBHttpClientConnection;
-import org.apache.http.io.SessionInputBuffer;
-import org.apache.http.io.SessionOutputBuffer;
-
-class BenchmarkConnection extends DefaultBHttpClientConnection {
-
-    private final Stats stats;
-
-    BenchmarkConnection(final int bufsize, final Stats stats) {
-        super(bufsize);
-        this.stats = stats;
-    }
-
-    @Override
-    protected OutputStream createContentOutputStream(final long len,
-                                                     final SessionOutputBuffer outbuffer,
-                                                     final TrailerSupplier trailers) {
-        return new CountingOutputStream(super.createContentOutputStream(len, outbuffer, trailers), this.stats);
-    }
-
-    @Override
-    protected InputStream createContentInputStream(final long len, final SessionInputBuffer inbuffer) {
-        return new CountingInputStream(super.createContentInputStream(len, inbuffer), this.stats);
-    }
-
+public interface TrailerSupplier {
+    /**
+     * It's called before and after body sent.
+     * First time is to collect names for Trailer,
+     * values should be null.
+     */
+    Header[] get();
 }

--- a/httpcore/src/main/java/org/apache/http/entity/AbstractHttpEntity.java
+++ b/httpcore/src/main/java/org/apache/http/entity/AbstractHttpEntity.java
@@ -27,6 +27,9 @@
 
 package org.apache.http.entity;
 
+import static org.apache.http.EmptyTrailerSupplier.instance;
+
+import org.apache.http.TrailerSupplier;
 import org.apache.http.annotation.NotThreadSafe;
 
 /**
@@ -48,6 +51,7 @@ public abstract class AbstractHttpEntity extends AbstractImmutableHttpEntity {
     private String contentType;
     private String contentEncoding;
     private boolean chunked;
+    private TrailerSupplier trailers = instance;
 
     @Override
     public String getContentType() {
@@ -76,4 +80,14 @@ public abstract class AbstractHttpEntity extends AbstractImmutableHttpEntity {
         this.chunked = b;
     }
 
+    public void setTrailers(final TrailerSupplier trailers) {
+        if (trailers == null) {
+            throw new NullPointerException();
+        }
+        this.trailers = trailers;
+    }
+
+    public TrailerSupplier getTrailers() {
+        return trailers;
+    }
 }

--- a/httpcore/src/main/java/org/apache/http/entity/HttpEntityWrapper.java
+++ b/httpcore/src/main/java/org/apache/http/entity/HttpEntityWrapper.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 import org.apache.http.HttpEntity;
+import org.apache.http.TrailerSupplier;
 import org.apache.http.annotation.NotThreadSafe;
 import org.apache.http.util.Args;
 
@@ -100,4 +101,8 @@ public class HttpEntityWrapper implements HttpEntity {
         return wrappedEntity.isStreaming();
     }
 
+    @Override
+    public TrailerSupplier getTrailers() {
+        return wrappedEntity.getTrailers();
+    }
 }

--- a/httpcore/src/main/java/org/apache/http/impl/BHttpConnectionBase.java
+++ b/httpcore/src/main/java/org/apache/http/impl/BHttpConnectionBase.java
@@ -45,6 +45,7 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpException;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpMessage;
+import org.apache.http.TrailerSupplier;
 import org.apache.http.config.MessageConstraints;
 import org.apache.http.entity.ContentLengthStrategy;
 import org.apache.http.impl.io.ChunkedInputStream;
@@ -138,11 +139,12 @@ class BHttpConnectionBase implements BHttpConnection {
 
     protected OutputStream createContentOutputStream(
             final long len,
-            final SessionOutputBuffer outbuffer) {
+            final SessionOutputBuffer outbuffer,
+            final TrailerSupplier trailers) {
         if (len >= 0) {
             return new ContentLengthOutputStream(outbuffer, len);
         } else if (len == ContentLengthStrategy.CHUNKED) {
-            return new ChunkedOutputStream(2048, outbuffer);
+            return new ChunkedOutputStream(2048, outbuffer, trailers);
         } else {
             return new IdentityOutputStream(outbuffer);
         }

--- a/httpcore/src/main/java/org/apache/http/impl/DefaultBHttpClientConnection.java
+++ b/httpcore/src/main/java/org/apache/http/impl/DefaultBHttpClientConnection.java
@@ -45,6 +45,7 @@ import org.apache.http.HttpStatus;
 import org.apache.http.annotation.NotThreadSafe;
 import org.apache.http.config.MessageConstraints;
 import org.apache.http.entity.ContentLengthStrategy;
+import org.apache.http.impl.entity.CheckUndefinedDecorator;
 import org.apache.http.impl.entity.DefaultContentLengthStrategy;
 import org.apache.http.impl.io.DefaultHttpRequestWriterFactory;
 import org.apache.http.impl.io.DefaultHttpResponseParserFactory;
@@ -106,8 +107,10 @@ public class DefaultBHttpClientConnection extends BHttpConnectionBase
             DefaultHttpResponseParserFactory.INSTANCE).create(constraints);
         this.incomingContentStrategy = incomingContentStrategy != null ? incomingContentStrategy :
                 DefaultContentLengthStrategy.INSTANCE;
-        this.outgoingContentStrategy = outgoingContentStrategy != null ? outgoingContentStrategy :
-                DefaultContentLengthStrategy.INSTANCE;
+        this.outgoingContentStrategy = new CheckUndefinedDecorator(
+                outgoingContentStrategy != null
+                        ? outgoingContentStrategy
+                        : DefaultContentLengthStrategy.INSTANCE);
         this.consistent = true;
     }
 
@@ -209,5 +212,4 @@ public class DefaultBHttpClientConnection extends BHttpConnectionBase
         }
         response.setEntity(createIncomingEntity(response, this.inbuffer, len));
     }
-
 }

--- a/httpcore/src/main/java/org/apache/http/impl/DefaultBHttpClientConnection.java
+++ b/httpcore/src/main/java/org/apache/http/impl/DefaultBHttpClientConnection.java
@@ -33,6 +33,7 @@ import java.net.Socket;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
 
+import org.apache.http.EmptyTrailerSupplier;
 import org.apache.http.HttpClientConnection;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpException;
@@ -40,6 +41,7 @@ import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.LengthRequiredException;
+import org.apache.http.ProtocolException;
 import org.apache.http.annotation.NotThreadSafe;
 import org.apache.http.config.MessageConstraints;
 import org.apache.http.entity.ContentLengthStrategy;
@@ -150,13 +152,27 @@ public class DefaultBHttpClientConnection extends BHttpConnectionBase
         if (entity == null) {
             return;
         }
+        final OutputStream outstream = createContentOutputStream(
+                determineLength(request, entity),
+                this.outbuffer, entity.getTrailers());
+        entity.writeTo(outstream);
+        outstream.close();
+    }
+
+    private long determineLength(final HttpRequest request,
+                                 final HttpEntity entity)
+            throws HttpException {
+        final boolean hasTrailers = entity.getTrailers() != EmptyTrailerSupplier.instance;
+        if (hasTrailers && !entity.isChunked()) {
+            throw new ProtocolException("Request with trailers should have chunked encoding");
+        }
         final long len = this.outgoingContentStrategy.determineLength(request);
         if (len == ContentLengthStrategy.UNDEFINED) {
             throw new LengthRequiredException("Length required");
+        } else if (hasTrailers && len != ContentLengthStrategy.CHUNKED) {
+            throw new ProtocolException("Request with trailers should have chunked encoding");
         }
-        final OutputStream outstream = createContentOutputStream(len, this.outbuffer);
-        entity.writeTo(outstream);
-        outstream.close();
+        return len;
     }
 
     @Override
@@ -172,12 +188,14 @@ public class DefaultBHttpClientConnection extends BHttpConnectionBase
         if (entity == null) {
             return;
         }
-        final long len = this.outgoingContentStrategy.determineLength(request);
+        final long len = determineLength(request, entity);
         if (len == ContentLengthStrategy.CHUNKED) {
-            final OutputStream outstream = createContentOutputStream(len, this.outbuffer);
+            final OutputStream outstream = createContentOutputStream(len, this.outbuffer,
+                    entity.getTrailers());
             outstream.close();
         } else if (len >= 0 && len <= 1024) {
-            final OutputStream outstream = createContentOutputStream(len, this.outbuffer);
+            final OutputStream outstream = createContentOutputStream(len, this.outbuffer,
+                    EmptyTrailerSupplier.instance);
             entity.writeTo(outstream);
             outstream.close();
         } else {

--- a/httpcore/src/main/java/org/apache/http/impl/DefaultBHttpServerConnection.java
+++ b/httpcore/src/main/java/org/apache/http/impl/DefaultBHttpServerConnection.java
@@ -33,6 +33,7 @@ import java.net.Socket;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
 
+import org.apache.http.EmptyTrailerSupplier;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;
@@ -174,9 +175,9 @@ public class DefaultBHttpServerConnection extends BHttpConnectionBase
             return;
         }
         final long len = this.outgoingContentStrategy.determineLength(response);
-        final OutputStream outstream = createContentOutputStream(len, this.outbuffer);
+        final OutputStream outstream = createContentOutputStream(len, this.outbuffer,
+                EmptyTrailerSupplier.instance);
         entity.writeTo(outstream);
         outstream.close();
     }
-
 }

--- a/httpcore/src/main/java/org/apache/http/impl/DefaultBHttpServerConnection.java
+++ b/httpcore/src/main/java/org/apache/http/impl/DefaultBHttpServerConnection.java
@@ -27,13 +27,14 @@
 
 package org.apache.http.impl;
 
+import static org.apache.http.impl.entity.DefaultContentLengthStrategy.determineLength;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.Socket;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
 
-import org.apache.http.EmptyTrailerSupplier;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;
@@ -174,9 +175,10 @@ public class DefaultBHttpServerConnection extends BHttpConnectionBase
         if (entity == null) {
             return;
         }
-        final long len = this.outgoingContentStrategy.determineLength(response);
-        final OutputStream outstream = createContentOutputStream(len, this.outbuffer,
-                EmptyTrailerSupplier.instance);
+        final OutputStream outstream = createContentOutputStream(
+                determineLength(outgoingContentStrategy, response, entity),
+                this.outbuffer,
+                entity.getTrailers());
         entity.writeTo(outstream);
         outstream.close();
     }

--- a/httpcore/src/main/java/org/apache/http/impl/IncomingHttpEntity.java
+++ b/httpcore/src/main/java/org/apache/http/impl/IncomingHttpEntity.java
@@ -27,10 +27,13 @@
 
 package org.apache.http.impl;
 
+import static org.apache.http.EmptyTrailerSupplier.instance;
+
 import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.http.Header;
+import org.apache.http.TrailerSupplier;
 import org.apache.http.annotation.NotThreadSafe;
 import org.apache.http.entity.AbstractImmutableHttpEntity;
 import org.apache.http.impl.io.EmptyInputStream;
@@ -48,13 +51,24 @@ public class IncomingHttpEntity extends AbstractImmutableHttpEntity {
     private final boolean chunked;
     private final Header contentType;
     private final Header contentEncoding;
+    private final TrailerSupplier trailers;
 
-    public IncomingHttpEntity(final InputStream content, final long len, final boolean chunked, final Header contentType, final Header contentEncoding) {
+    public IncomingHttpEntity(final InputStream content, final long len,
+                              final boolean chunked, final Header contentType,
+                              final Header contentEncoding) {
+        this(content, len, chunked, contentType, contentEncoding, instance);
+    }
+
+    public IncomingHttpEntity(final InputStream content, final long len,
+                              final boolean chunked, final Header contentType,
+                              final Header contentEncoding,
+                              final TrailerSupplier trailers) {
         this.content = content;
         this.len = len;
         this.chunked = chunked;
         this.contentType = contentType;
         this.contentEncoding = contentEncoding;
+        this.trailers = trailers;
     }
 
     @Override
@@ -92,4 +106,8 @@ public class IncomingHttpEntity extends AbstractImmutableHttpEntity {
         return content != null && content != EmptyInputStream.INSTANCE;
     }
 
+    @Override
+    public TrailerSupplier getTrailers() {
+        return trailers;
+    }
 }

--- a/httpcore/src/main/java/org/apache/http/impl/entity/CheckUndefinedDecorator.java
+++ b/httpcore/src/main/java/org/apache/http/impl/entity/CheckUndefinedDecorator.java
@@ -1,0 +1,50 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http.impl.entity;
+
+import org.apache.http.HttpException;
+import org.apache.http.HttpMessage;
+import org.apache.http.LengthRequiredException;
+import org.apache.http.entity.ContentLengthStrategy;
+
+public class CheckUndefinedDecorator implements ContentLengthStrategy {
+    private final ContentLengthStrategy forward;
+
+    public CheckUndefinedDecorator(final ContentLengthStrategy forward) {
+        this.forward = forward;
+    }
+
+    @Override
+    public long determineLength(final HttpMessage message) throws HttpException {
+        final long length = forward.determineLength(message);
+        if (length == UNDEFINED) {
+            throw new LengthRequiredException("Length required");
+        }
+        return length;
+    }
+}

--- a/httpcore/src/main/java/org/apache/http/impl/entity/DefaultContentLengthStrategy.java
+++ b/httpcore/src/main/java/org/apache/http/impl/entity/DefaultContentLengthStrategy.java
@@ -34,7 +34,6 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpException;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpMessage;
-import org.apache.http.LengthRequiredException;
 import org.apache.http.NotImplementedException;
 import org.apache.http.ProtocolException;
 import org.apache.http.annotation.Immutable;
@@ -105,9 +104,7 @@ public class DefaultContentLengthStrategy implements ContentLengthStrategy {
             throw new ProtocolException("Request with trailers should have chunked encoding");
         }
         final long len = strategy.determineLength(message);
-        if (len == ContentLengthStrategy.UNDEFINED) {
-            throw new LengthRequiredException("Length required");
-        } else if (hasTrailers && len != ContentLengthStrategy.CHUNKED) {
+        if (hasTrailers && len != ContentLengthStrategy.CHUNKED) {
             throw new ProtocolException("Request with trailers should have chunked encoding");
         }
         return len;

--- a/httpcore/src/main/java/org/apache/http/impl/io/AbstractMessageWriter.java
+++ b/httpcore/src/main/java/org/apache/http/impl/io/AbstractMessageWriter.java
@@ -51,8 +51,8 @@ import org.apache.http.util.CharArrayBuffer;
 @NotThreadSafe
 public abstract class AbstractMessageWriter<T extends HttpMessage> implements HttpMessageWriter<T> {
 
-    private final CharArrayBuffer lineBuf;
-    private final LineFormatter lineFormatter;
+    protected final CharArrayBuffer lineBuf;
+    protected final LineFormatter lineFormatter;
 
     /**
      * Creates an instance of AbstractMessageWriter.
@@ -98,8 +98,11 @@ public abstract class AbstractMessageWriter<T extends HttpMessage> implements Ht
                 buffer.writeLine(this.lineBuf);
             }
         }
+        addTrailerHeader(buffer, message);
         this.lineBuf.clear();
         buffer.writeLine(this.lineBuf);
     }
 
+    protected void addTrailerHeader(final SessionOutputBuffer buffer, final T message)
+            throws IOException {}
 }

--- a/httpcore/src/test/java/org/apache/http/impl/io/TestChunkCoding.java
+++ b/httpcore/src/test/java/org/apache/http/impl/io/TestChunkCoding.java
@@ -34,6 +34,7 @@ import java.io.InterruptedIOException;
 import java.io.OutputStream;
 
 import org.apache.http.ConnectionClosedException;
+import org.apache.http.ConstTrailerSupplier;
 import org.apache.http.Consts;
 import org.apache.http.Header;
 import org.apache.http.MalformedChunkCodingException;
@@ -43,6 +44,7 @@ import org.apache.http.config.MessageConstraints;
 import org.apache.http.impl.SessionInputBufferMock;
 import org.apache.http.impl.SessionOutputBufferMock;
 import org.apache.http.io.SessionInputBuffer;
+import org.apache.http.message.BasicHeader;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -362,7 +364,48 @@ public class TestChunkCoding {
         final String output = new String(result.toByteArray(), Consts.ISO_8859_1);
         Assert.assertEquals(input, output);
         in.close();
-}
+    }
+
+    @Test
+    public void testChunkedOutputStreamWithTrailers() throws IOException {
+        final SessionOutputBufferMock buffer = new SessionOutputBufferMock();
+        final Header[] trailers = new Header[] {
+                new BasicHeader("SKIP-CAUSE-NULL", null),
+                new BasicHeader("E", ""),
+                new BasicHeader("Y", "Z")
+        };
+        final ChunkedOutputStream out = new ChunkedOutputStream(2, buffer,
+                new ConstTrailerSupplier(trailers));
+        out.write('x');
+        out.finish();
+        out.close();
+
+        final byte [] rawdata =  buffer.getData();
+
+        Assert.assertEquals(22, rawdata.length);
+        Assert.assertEquals('1', rawdata[0]);
+        Assert.assertEquals('\r', rawdata[1]);
+        Assert.assertEquals('\n', rawdata[2]);
+        Assert.assertEquals('x', rawdata[3]);
+        Assert.assertEquals('\r', rawdata[4]);
+        Assert.assertEquals('\n', rawdata[5]);
+        Assert.assertEquals('0', rawdata[6]);
+        Assert.assertEquals('\r', rawdata[7]);
+        Assert.assertEquals('\n', rawdata[8]);
+        Assert.assertEquals('E', rawdata[9]);
+        Assert.assertEquals(':', rawdata[10]);
+        Assert.assertEquals(' ', rawdata[11]);
+        Assert.assertEquals('\r', rawdata[12]);
+        Assert.assertEquals('\n', rawdata[13]);
+        Assert.assertEquals('Y', rawdata[14]);
+        Assert.assertEquals(':', rawdata[15]);
+        Assert.assertEquals(' ', rawdata[16]);
+        Assert.assertEquals('Z', rawdata[17]);
+        Assert.assertEquals('\r', rawdata[18]);
+        Assert.assertEquals('\n', rawdata[19]);
+        Assert.assertEquals('\r', rawdata[20]);
+        Assert.assertEquals('\n', rawdata[21]);
+    }
 
     @Test
     public void testChunkedOutputStream() throws IOException {


### PR DESCRIPTION
In this version trailers are presented as 1 supplier for array of Headers.
Server side also supports trailers in response.
I had to extract content length strategy decorator and static method to avoid duplication.
Yeah the decorator breaks a little bit contract but it's used in a private field.
