### PR TITLE
HTTPCORE-412 trailers as Header[] and getExpectedTrailerNames

### DIFF
--- a/httpcore-ab/src/main/java/org/apache/http/benchmark/BenchmarkConnection.java
+++ b/httpcore-ab/src/main/java/org/apache/http/benchmark/BenchmarkConnection.java
@@ -28,7 +28,9 @@ package org.apache.http.benchmark;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Set;
 
+import org.apache.http.TrailerSupplier;
 import org.apache.http.impl.DefaultBHttpClientConnection;
 import org.apache.http.io.SessionInputBuffer;
 import org.apache.http.io.SessionOutputBuffer;
@@ -43,8 +45,13 @@ class BenchmarkConnection extends DefaultBHttpClientConnection {
     }
 
     @Override
-    protected OutputStream createContentOutputStream(final long len, final SessionOutputBuffer outbuffer) {
-        return new CountingOutputStream(super.createContentOutputStream(len, outbuffer), this.stats);
+    protected OutputStream createContentOutputStream(final long len,
+                                                     final SessionOutputBuffer outbuffer,
+                                                     final TrailerSupplier trailers,
+                                                     final Set<String> expectedTrailerNames) {
+        return new CountingOutputStream(
+                super.createContentOutputStream(len, outbuffer, trailers, expectedTrailerNames),
+                this.stats);
     }
 
     @Override

--- a/httpcore-nio/src/examples/org/apache/http/examples/nio/NHttpClientPostWithTrailers.java
+++ b/httpcore-nio/src/examples/org/apache/http/examples/nio/NHttpClientPostWithTrailers.java
@@ -58,6 +58,7 @@ import org.apache.http.protocol.RequestConnControl;
 import org.apache.http.protocol.RequestContent;
 import org.apache.http.protocol.RequestExpectContinue;
 import org.apache.http.protocol.RequestTargetHost;
+import org.apache.http.protocol.RequestTrailer;
 import org.apache.http.protocol.RequestUserAgent;
 
 /**
@@ -68,6 +69,7 @@ public class NHttpClient {
         // Create HTTP protocol processing chain
         HttpProcessor httpproc = HttpProcessorBuilder.create()
                 // Use standard client-side protocol interceptors
+                .add(new RequestTrailer())
                 .add(new RequestContent())
                 .add(new RequestTargetHost())
                 .add(new RequestConnControl())

--- a/httpcore-nio/src/examples/org/apache/http/examples/nio/NHttpClientPostWithTrailers.java
+++ b/httpcore-nio/src/examples/org/apache/http/examples/nio/NHttpClientPostWithTrailers.java
@@ -1,0 +1,149 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.http.examples.nio;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.util.concurrent.CountDownLatch;
+
+import org.apache.http.ConstTrailerSupplier;
+import org.apache.http.Consts;
+import org.apache.http.Header;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.config.ConnectionConfig;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.impl.nio.DefaultHttpClientIODispatch;
+import org.apache.http.impl.nio.pool.BasicNIOConnPool;
+import org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicHttpRequest;
+import org.apache.http.nio.protocol.BasicAsyncRequestProducer;
+import org.apache.http.nio.protocol.BasicAsyncResponseConsumer;
+import org.apache.http.nio.protocol.HttpAsyncRequestExecutor;
+import org.apache.http.nio.protocol.HttpAsyncRequester;
+import org.apache.http.nio.reactor.ConnectingIOReactor;
+import org.apache.http.nio.reactor.IOEventDispatch;
+import org.apache.http.protocol.HttpCoreContext;
+import org.apache.http.protocol.HttpProcessor;
+import org.apache.http.protocol.HttpProcessorBuilder;
+import org.apache.http.protocol.RequestConnControl;
+import org.apache.http.protocol.RequestContent;
+import org.apache.http.protocol.RequestExpectContinue;
+import org.apache.http.protocol.RequestTargetHost;
+import org.apache.http.protocol.RequestUserAgent;
+
+/**
+ * Minimal asynchronous HTTP/1.1 client sending POST request with trailers.
+ */
+public class NHttpClient {
+    public static void main(String[] args) throws Exception {
+        // Create HTTP protocol processing chain
+        HttpProcessor httpproc = HttpProcessorBuilder.create()
+                // Use standard client-side protocol interceptors
+                .add(new RequestContent())
+                .add(new RequestTargetHost())
+                .add(new RequestConnControl())
+                .add(new RequestUserAgent("Test/1.1"))
+                .add(new RequestExpectContinue()).build();
+        // Create client-side HTTP protocol handler
+        HttpAsyncRequestExecutor protocolHandler = new HttpAsyncRequestExecutor();
+        // Create client-side I/O event dispatch
+        final IOEventDispatch ioEventDispatch = new DefaultHttpClientIODispatch(protocolHandler,
+                ConnectionConfig.DEFAULT);
+        // Create client-side I/O reactor
+        final ConnectingIOReactor ioReactor = new DefaultConnectingIOReactor();
+        // Create HTTP connection pool
+        BasicNIOConnPool pool = new BasicNIOConnPool(ioReactor, ConnectionConfig.DEFAULT);
+        // Limit total number of connections to just two
+        pool.setDefaultMaxPerRoute(2);
+        pool.setMaxTotal(2);
+        // Run the I/O reactor in a separate thread
+        Thread t = new Thread(new Runnable() {
+
+            @Override
+            public void run() {
+                try {
+                    // Ready to go!
+                    ioReactor.execute(ioEventDispatch);
+                } catch (InterruptedIOException ex) {
+                    System.err.println("Interrupted");
+                } catch (IOException e) {
+                    System.err.println("I/O error: " + e.getMessage());
+                }
+                System.out.println("Shutdown");
+            }
+
+        });
+        // Start the client thread
+        t.start();
+        // Create HTTP requester
+        HttpAsyncRequester requester = new HttpAsyncRequester(httpproc);
+        final HttpHost target = new HttpHost("localhost", 8080, "http");
+        final CountDownLatch latch = new CountDownLatch(1);
+        InputStreamEntity requestBody =
+                new InputStreamEntity(
+                        new ByteArrayInputStream(
+                                "This is the third test request (will be chunked)"
+                                        .getBytes(Consts.UTF_8)),
+                        ContentType.APPLICATION_OCTET_STREAM);
+        requestBody.setExpectedTrailerNames(new HashSet<String>(asList("t1")));
+        requestBody.setChunked(true);
+        requestBody.setTrailers(new ConstTrailerSupplier(
+                new Header[] { new BasicHeader("t1","Hello world") }));
+        BasicHttpRequest request = new BasicHttpRequest("POST", "/");
+        request.setEntity(requestBody);
+        HttpCoreContext coreContext = HttpCoreContext.create();
+        requester.execute(
+                new BasicAsyncRequestProducer(target, request),
+                new BasicAsyncResponseConsumer(),
+                pool,
+                coreContext,
+                // Handle HTTP response from a callback
+                new FutureCallback<HttpResponse>() {
+                    public void completed(final HttpResponse response) {
+                        latch.countDown();
+                        System.out.println(target + "->" + response.getStatusLine());
+                    }
+                    public void failed(final Exception ex) {
+                        latch.countDown();
+                        System.out.println(target + "->" + ex);
+                    }
+                    public void cancelled() {
+                        latch.countDown();
+                        System.out.println(target + " cancelled");
+                    }
+                });
+        latch.await();
+        System.out.println("Shutting down I/O reactor");
+        ioReactor.shutdown();
+        System.out.println("Done");
+    }
+}

--- a/httpcore-nio/src/main/java/org/apache/http/impl/nio/DefaultNHttpServerConnection.java
+++ b/httpcore-nio/src/main/java/org/apache/http/impl/nio/DefaultNHttpServerConnection.java
@@ -27,6 +27,8 @@
 
 package org.apache.http.impl.nio;
 
+import static org.apache.http.impl.entity.DefaultContentLengthStrategy.determineLength;
+
 import java.io.IOException;
 import java.nio.channels.SelectionKey;
 import java.nio.charset.CharsetDecoder;
@@ -269,14 +271,16 @@ public class DefaultNHttpServerConnection
 
         if (response.getStatusLine().getStatusCode() >= 200) {
             this.connMetrics.incrementResponseCount();
-            if (response.getEntity() != null) {
+            final HttpEntity entity = response.getEntity();
+            if (entity != null) {
                 this.response = response;
-                final long len = this.outgoingContentStrategy.determineLength(response);
                 this.contentEncoder = createContentEncoder(
-                        len,
+                        determineLength(outgoingContentStrategy, response, entity),
                         this.session.channel(),
                         this.outbuf,
-                        this.outTransportMetrics);
+                        this.outTransportMetrics,
+                        entity.getTrailers(),
+                        entity.getExpectedTrailerNames());
             }
         }
 

--- a/httpcore-nio/src/test/java/org/apache/http/impl/nio/codecs/TestChunkEncoder.java
+++ b/httpcore-nio/src/test/java/org/apache/http/impl/nio/codecs/TestChunkEncoder.java
@@ -27,12 +27,20 @@
 
 package org.apache.http.impl.nio.codecs;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 
+import org.apache.http.ConstTrailerSupplier;
 import org.apache.http.Consts;
+import org.apache.http.EmptyTrailerSupplier;
+import org.apache.http.Header;
 import org.apache.http.WritableByteChannelMock;
 import org.apache.http.impl.io.HttpTransportMetricsImpl;
 import org.apache.http.impl.nio.reactor.SessionOutputBufferImpl;
+import org.apache.http.message.BasicHeader;
 import org.apache.http.nio.reactor.SessionOutputBuffer;
 import org.junit.Assert;
 import org.junit.Test;
@@ -120,7 +128,8 @@ public class TestChunkEncoder {
         final WritableByteChannelMock channel = Mockito.spy(new WritableByteChannelMock(1024));
         final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 1024);
         final HttpTransportMetricsImpl metrics = new HttpTransportMetricsImpl();
-        final ChunkEncoder encoder = new ChunkEncoder(channel, outbuf, metrics, 1024);
+        final ChunkEncoder encoder = new ChunkEncoder(channel, outbuf, metrics, 1024,
+                EmptyTrailerSupplier.instance, Collections.<String>emptySet());
 
         Assert.assertEquals(16, encoder.write(CodecTestUtils.wrap("0123456789ABCDEF")));
         Assert.assertEquals(16, encoder.write(CodecTestUtils.wrap("0123456789ABCDEF")));
@@ -229,4 +238,27 @@ public class TestChunkEncoder {
         }
     }
 
+    @Test
+    public void testTrailers() throws IOException {
+        final WritableByteChannelMock channel = new WritableByteChannelMock(64);
+        final SessionOutputBuffer outbuf = new SessionOutputBufferImpl(1024, 128);
+        final HttpTransportMetricsImpl metrics = new HttpTransportMetricsImpl();
+        final ChunkEncoder encoder = new ChunkEncoder(channel, outbuf, metrics, 0,
+                new ConstTrailerSupplier(new Header[] {
+                        new BasicHeader("E", ""),
+                        new BasicHeader("Y", "Z")
+                }),
+                new HashSet<>(Arrays.asList("E", "Y")));
+        encoder.write(CodecTestUtils.wrap("1"));
+        encoder.write(CodecTestUtils.wrap("23"));
+        encoder.complete();
+
+        outbuf.flush(channel);
+
+        final String s = channel.dump(Consts.ASCII);
+
+        Assert.assertTrue(encoder.isCompleted());
+        Assert.assertEquals("1\r\n1\r\n2\r\n23\r\n0\r\nE: \r\nY: Z\r\n\r\n", s);
+        Assert.assertEquals("[chunk-coded; completed: true]", encoder.toString());
+    }
 }

--- a/httpcore-nio/src/test/java/org/apache/http/nio/integration/TestTruncatedChunks.java
+++ b/httpcore-nio/src/test/java/org/apache/http/nio/integration/TestTruncatedChunks.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
@@ -40,6 +41,7 @@ import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.MalformedChunkCodingException;
+import org.apache.http.TrailerSupplier;
 import org.apache.http.TruncatedChunkException;
 import org.apache.http.entity.ContentLengthStrategy;
 import org.apache.http.entity.ContentType;
@@ -153,11 +155,14 @@ public class TestTruncatedChunks extends HttpCoreNIOTestBase {
                         final long len,
                         final WritableByteChannel channel,
                         final SessionOutputBuffer buffer,
-                        final HttpTransportMetricsImpl metrics) {
+                        final HttpTransportMetricsImpl metrics,
+                        final TrailerSupplier trailers,
+                        final Set<String> expectedTrailerNames) {
                     if (len == ContentLengthStrategy.CHUNKED) {
                         return new BrokenChunkEncoder(channel, buffer, metrics);
                     } else {
-                        return super.createContentEncoder(len, channel, buffer, metrics);
+                        return super.createContentEncoder(len, channel, buffer,
+                                metrics, trailers, expectedTrailerNames);
                     }
                 }
 

--- a/httpcore/src/examples/org/apache/http/examples/ElementalHttpPostTrailers.java
+++ b/httpcore/src/examples/org/apache/http/examples/ElementalHttpPostTrailers.java
@@ -1,0 +1,104 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http.examples;
+
+import static java.util.Arrays.asList;
+
+import java.io.ByteArrayInputStream;
+import java.net.Socket;
+import java.util.HashSet;
+
+import org.apache.http.ConstTrailerSupplier;
+import org.apache.http.Consts;
+import org.apache.http.Header;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.impl.DefaultBHttpClientConnection;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicHttpRequest;
+import org.apache.http.protocol.HttpCoreContext;
+import org.apache.http.protocol.HttpProcessor;
+import org.apache.http.protocol.HttpProcessorBuilder;
+import org.apache.http.protocol.HttpRequestExecutor;
+import org.apache.http.protocol.RequestConnControl;
+import org.apache.http.protocol.RequestContent;
+import org.apache.http.protocol.RequestTargetHost;
+import org.apache.http.protocol.RequestUserAgent;
+import org.apache.http.util.EntityUtils;
+
+/**
+ * Elemental example for executing POST request with trailing headers
+ *
+ * <pre>{@code
+ * protected void doPost(HttpServletRequest req, HttpServletResponse resp)
+ *            throws ServletException, IOException {
+ *       // read all body first
+ *       IOUtils.copy(req.getInputStream(), resp.getOutputStream());
+ *       logger.info("t1 trailer header is [{}]", req.getHeader("t1"));
+ *   }
+ * }</pre>
+ */
+public class ElementalHttpPost {
+    public static void main(String[] args) throws Exception {
+        HttpProcessor httpproc = HttpProcessorBuilder.create()
+                .add(new RequestContent())
+                .add(new RequestTargetHost())
+                .add(new RequestConnControl())
+                .add(new RequestUserAgent("Test/1.1"))
+                .build();
+        HttpRequestExecutor httpexecutor = new HttpRequestExecutor();
+        HttpCoreContext coreContext = HttpCoreContext.create();
+        HttpHost host = new HttpHost("localhost", 8080);
+        coreContext.setTargetHost(host);
+        DefaultBHttpClientConnection conn = new DefaultBHttpClientConnection(8 * 1024);
+        InputStreamEntity requestBody =
+                new InputStreamEntity(
+                        new ByteArrayInputStream(
+                                "This is the third test request (will be chunked)"
+                                        .getBytes(Consts.UTF_8)),
+                        ContentType.APPLICATION_OCTET_STREAM);
+        requestBody.setTrailers(new ConstTrailerSupplier(
+                new Header[] { new BasicHeader("t1","Hello world") }));
+        requestBody.setExpectedTrailerNames(new HashSet<String>(asList("t1")));
+        requestBody.setChunked(true);
+        Socket socket = new Socket(host.getHostName(), host.getPort());
+        conn.bind(socket);
+        BasicHttpRequest request = new BasicHttpRequest("POST", "/");
+        request.setEntity(requestBody);
+        httpexecutor.preProcess(request, httpproc, coreContext);
+        HttpResponse response = httpexecutor.execute(request, conn, coreContext);
+        httpexecutor.postProcess(response, httpproc, coreContext);
+
+        System.out.println("<< Response: " + response.getStatusLine());
+        System.out.println(EntityUtils.toString(response.getEntity()));
+        System.out.println("==============");
+        conn.close();
+    }
+}

--- a/httpcore/src/examples/org/apache/http/examples/ElementalHttpPostTrailers.java
+++ b/httpcore/src/examples/org/apache/http/examples/ElementalHttpPostTrailers.java
@@ -50,6 +50,7 @@ import org.apache.http.protocol.HttpRequestExecutor;
 import org.apache.http.protocol.RequestConnControl;
 import org.apache.http.protocol.RequestContent;
 import org.apache.http.protocol.RequestTargetHost;
+import org.apache.http.protocol.RequestTrailer;
 import org.apache.http.protocol.RequestUserAgent;
 import org.apache.http.util.EntityUtils;
 
@@ -68,6 +69,7 @@ import org.apache.http.util.EntityUtils;
 public class ElementalHttpPost {
     public static void main(String[] args) throws Exception {
         HttpProcessor httpproc = HttpProcessorBuilder.create()
+                .add(new RequestTrailer())
                 .add(new RequestContent())
                 .add(new RequestTargetHost())
                 .add(new RequestConnControl())

--- a/httpcore/src/main/java/org/apache/http/ConstTrailerSupplier.java
+++ b/httpcore/src/main/java/org/apache/http/ConstTrailerSupplier.java
@@ -1,0 +1,41 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http;
+
+public class ConstTrailerSupplier implements TrailerSupplier {
+    private final Header[] values;
+
+    public ConstTrailerSupplier(final Header[] values) {
+        this.values = values;
+    }
+
+    @Override
+    public Header[] get() {
+        return values;
+    }
+}

--- a/httpcore/src/main/java/org/apache/http/EmptyTrailerSupplier.java
+++ b/httpcore/src/main/java/org/apache/http/EmptyTrailerSupplier.java
@@ -1,0 +1,39 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http;
+
+public class EmptyTrailerSupplier implements TrailerSupplier {
+    private static final Header[] EMPTY = new Header[0];
+    public static final EmptyTrailerSupplier instance = new EmptyTrailerSupplier();
+
+    private EmptyTrailerSupplier() {}
+
+    public Header[] get() {
+        return EMPTY;
+    }
+}

--- a/httpcore/src/main/java/org/apache/http/HttpEntity.java
+++ b/httpcore/src/main/java/org/apache/http/HttpEntity.java
@@ -30,6 +30,7 @@ package org.apache.http;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Set;
 
 /**
  * An entity that can be sent or received with an HTTP message.
@@ -166,4 +167,15 @@ public interface HttpEntity {
      */
     boolean isStreaming(); // don't expect an exception here
 
+    /**
+     * HTTP trailers - headers after request body.
+     * Callback is called only after body transferred.
+     */
+     TrailerSupplier getTrailers();
+
+    /**
+     * HTTP requires preliminary declaration of trailing headers
+     * @return names of expected trailing headers
+     */
+     Set<String> getExpectedTrailerNames();
 }

--- a/httpcore/src/main/java/org/apache/http/TrailerSupplier.java
+++ b/httpcore/src/main/java/org/apache/http/TrailerSupplier.java
@@ -1,0 +1,35 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http;
+
+public interface TrailerSupplier {
+    /**
+     * It's called after body is sent.
+     */
+    Header[] get();
+}

--- a/httpcore/src/main/java/org/apache/http/entity/AbstractHttpEntity.java
+++ b/httpcore/src/main/java/org/apache/http/entity/AbstractHttpEntity.java
@@ -27,6 +27,12 @@
 
 package org.apache.http.entity;
 
+import static org.apache.http.EmptyTrailerSupplier.instance;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.apache.http.TrailerSupplier;
 import org.apache.http.annotation.NotThreadSafe;
 
 /**
@@ -48,6 +54,8 @@ public abstract class AbstractHttpEntity extends AbstractImmutableHttpEntity {
     private String contentType;
     private String contentEncoding;
     private boolean chunked;
+    private TrailerSupplier trailers = instance;
+    private Set<String> expectedTrailerNames = Collections.emptySet();
 
     @Override
     public String getContentType() {
@@ -76,4 +84,25 @@ public abstract class AbstractHttpEntity extends AbstractImmutableHttpEntity {
         this.chunked = b;
     }
 
+    public void setTrailers(final TrailerSupplier trailers) {
+        if (trailers == null) {
+            throw new NullPointerException();
+        }
+        this.trailers = trailers;
+    }
+
+    public TrailerSupplier getTrailers() {
+        return trailers;
+    }
+
+    public void setExpectedTrailerNames(final Set<String> expectedTrailerNames) {
+        if (expectedTrailerNames == null) {
+            throw new NullPointerException();
+        }
+        this.expectedTrailerNames = expectedTrailerNames;
+    }
+
+    public Set<String> getExpectedTrailerNames() {
+        return expectedTrailerNames;
+    }
 }

--- a/httpcore/src/main/java/org/apache/http/entity/HttpEntityWrapper.java
+++ b/httpcore/src/main/java/org/apache/http/entity/HttpEntityWrapper.java
@@ -30,8 +30,10 @@ package org.apache.http.entity;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Set;
 
 import org.apache.http.HttpEntity;
+import org.apache.http.TrailerSupplier;
 import org.apache.http.annotation.NotThreadSafe;
 import org.apache.http.util.Args;
 
@@ -100,4 +102,13 @@ public class HttpEntityWrapper implements HttpEntity {
         return wrappedEntity.isStreaming();
     }
 
+    @Override
+    public TrailerSupplier getTrailers() {
+        return wrappedEntity.getTrailers();
+    }
+
+    @Override
+    public Set<String> getExpectedTrailerNames() {
+        return wrappedEntity.getExpectedTrailerNames();
+    }
 }

--- a/httpcore/src/main/java/org/apache/http/impl/BHttpConnectionBase.java
+++ b/httpcore/src/main/java/org/apache/http/impl/BHttpConnectionBase.java
@@ -36,6 +36,7 @@ import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.http.BHttpConnection;
@@ -45,6 +46,7 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpException;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpMessage;
+import org.apache.http.TrailerSupplier;
 import org.apache.http.config.MessageConstraints;
 import org.apache.http.entity.ContentLengthStrategy;
 import org.apache.http.impl.io.ChunkedInputStream;
@@ -138,11 +140,14 @@ class BHttpConnectionBase implements BHttpConnection {
 
     protected OutputStream createContentOutputStream(
             final long len,
-            final SessionOutputBuffer outbuffer) {
+            final SessionOutputBuffer outbuffer,
+            final TrailerSupplier trailers,
+            final Set<String> expectedTrailerNames) {
         if (len >= 0) {
             return new ContentLengthOutputStream(outbuffer, len);
         } else if (len == ContentLengthStrategy.CHUNKED) {
-            return new ChunkedOutputStream(2048, outbuffer);
+            return new ChunkedOutputStream(2048, outbuffer, trailers,
+                    expectedTrailerNames);
         } else {
             return new IdentityOutputStream(outbuffer);
         }

--- a/httpcore/src/main/java/org/apache/http/impl/DefaultBHttpServerConnection.java
+++ b/httpcore/src/main/java/org/apache/http/impl/DefaultBHttpServerConnection.java
@@ -27,6 +27,8 @@
 
 package org.apache.http.impl;
 
+import static org.apache.http.impl.entity.DefaultContentLengthStrategy.determineLength;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.Socket;
@@ -173,10 +175,12 @@ public class DefaultBHttpServerConnection extends BHttpConnectionBase
         if (entity == null) {
             return;
         }
-        final long len = this.outgoingContentStrategy.determineLength(response);
-        final OutputStream outstream = createContentOutputStream(len, this.outbuffer);
+        final OutputStream outstream = createContentOutputStream(
+                determineLength(outgoingContentStrategy, response, entity),
+                this.outbuffer,
+                entity.getTrailers(),
+                entity.getExpectedTrailerNames());
         entity.writeTo(outstream);
         outstream.close();
     }
-
 }

--- a/httpcore/src/main/java/org/apache/http/impl/IncomingHttpEntity.java
+++ b/httpcore/src/main/java/org/apache/http/impl/IncomingHttpEntity.java
@@ -27,10 +27,15 @@
 
 package org.apache.http.impl;
 
+import static org.apache.http.EmptyTrailerSupplier.instance;
+
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
+import java.util.Set;
 
 import org.apache.http.Header;
+import org.apache.http.TrailerSupplier;
 import org.apache.http.annotation.NotThreadSafe;
 import org.apache.http.entity.AbstractImmutableHttpEntity;
 import org.apache.http.impl.io.EmptyInputStream;
@@ -48,13 +53,34 @@ public class IncomingHttpEntity extends AbstractImmutableHttpEntity {
     private final boolean chunked;
     private final Header contentType;
     private final Header contentEncoding;
+    private final TrailerSupplier trailers;
+    private final Set<String> expectedTrailerNames;
 
-    public IncomingHttpEntity(final InputStream content, final long len, final boolean chunked, final Header contentType, final Header contentEncoding) {
+    public IncomingHttpEntity(final InputStream content, final long len,
+                              final boolean chunked, final Header contentType,
+                              final Header contentEncoding) {
+        this(content, len, chunked, contentType, contentEncoding,
+                instance, Collections.<String>emptySet());
+    }
+
+    public IncomingHttpEntity(final InputStream content, final long len,
+                              final boolean chunked, final Header contentType,
+                              final Header contentEncoding,
+                              final TrailerSupplier trailers,
+                              final Set<String> expectedTrailerNames) {
         this.content = content;
         this.len = len;
         this.chunked = chunked;
         this.contentType = contentType;
         this.contentEncoding = contentEncoding;
+        if (trailers == null) {
+            throw new NullPointerException();
+        }
+        this.trailers = trailers;
+        if (expectedTrailerNames == null) {
+            throw new NullPointerException();
+        }
+        this.expectedTrailerNames = expectedTrailerNames;
     }
 
     @Override
@@ -92,4 +118,13 @@ public class IncomingHttpEntity extends AbstractImmutableHttpEntity {
         return content != null && content != EmptyInputStream.INSTANCE;
     }
 
+    @Override
+    public TrailerSupplier getTrailers() {
+        return trailers;
+    }
+
+    @Override
+    public Set<String> getExpectedTrailerNames() {
+        return expectedTrailerNames;
+    }
 }

--- a/httpcore/src/main/java/org/apache/http/impl/entity/CheckUndefinedDecorator.java
+++ b/httpcore/src/main/java/org/apache/http/impl/entity/CheckUndefinedDecorator.java
@@ -1,0 +1,50 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.http.impl.entity;
+
+import org.apache.http.HttpException;
+import org.apache.http.HttpMessage;
+import org.apache.http.LengthRequiredException;
+import org.apache.http.entity.ContentLengthStrategy;
+
+public class CheckUndefinedDecorator implements ContentLengthStrategy {
+    private final ContentLengthStrategy forward;
+
+    public CheckUndefinedDecorator(final ContentLengthStrategy forward) {
+        this.forward = forward;
+    }
+
+    @Override
+    public long determineLength(final HttpMessage message) throws HttpException {
+        final long length = forward.determineLength(message);
+        if (length == UNDEFINED) {
+            throw new LengthRequiredException("Length required");
+        }
+        return length;
+    }
+}

--- a/httpcore/src/main/java/org/apache/http/impl/entity/DefaultContentLengthStrategy.java
+++ b/httpcore/src/main/java/org/apache/http/impl/entity/DefaultContentLengthStrategy.java
@@ -29,6 +29,7 @@ package org.apache.http.impl.entity;
 
 import org.apache.http.Header;
 import org.apache.http.HeaderElements;
+import org.apache.http.HttpEntity;
 import org.apache.http.HttpException;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpMessage;
@@ -93,4 +94,18 @@ public class DefaultContentLengthStrategy implements ContentLengthStrategy {
         return UNDEFINED;
     }
 
+    public static long determineLength(final ContentLengthStrategy strategy,
+                                       final HttpMessage message,
+                                       final HttpEntity entity)
+            throws HttpException {
+        final boolean hasTrailers = !entity.getExpectedTrailerNames().isEmpty();
+        if (hasTrailers && !entity.isChunked()) {
+            throw new ProtocolException("Request with trailers should have chunked encoding");
+        }
+        final long len = strategy.determineLength(message);
+        if (hasTrailers && len != ContentLengthStrategy.CHUNKED) {
+            throw new ProtocolException("Request with trailers should have chunked encoding");
+        }
+        return len;
+    }
 }

--- a/httpcore/src/main/java/org/apache/http/impl/io/AbstractMessageWriter.java
+++ b/httpcore/src/main/java/org/apache/http/impl/io/AbstractMessageWriter.java
@@ -98,11 +98,7 @@ public abstract class AbstractMessageWriter<T extends HttpMessage> implements Ht
                 buffer.writeLine(this.lineBuf);
             }
         }
-        addTrailerHeader(buffer, message);
         this.lineBuf.clear();
         buffer.writeLine(this.lineBuf);
     }
-
-    protected void addTrailerHeader(final SessionOutputBuffer buffer, final T message)
-            throws IOException {}
 }

--- a/httpcore/src/main/java/org/apache/http/impl/io/AbstractMessageWriter.java
+++ b/httpcore/src/main/java/org/apache/http/impl/io/AbstractMessageWriter.java
@@ -51,8 +51,8 @@ import org.apache.http.util.CharArrayBuffer;
 @NotThreadSafe
 public abstract class AbstractMessageWriter<T extends HttpMessage> implements HttpMessageWriter<T> {
 
-    private final CharArrayBuffer lineBuf;
-    private final LineFormatter lineFormatter;
+    protected final CharArrayBuffer lineBuf;
+    protected final LineFormatter lineFormatter;
 
     /**
      * Creates an instance of AbstractMessageWriter.
@@ -98,8 +98,11 @@ public abstract class AbstractMessageWriter<T extends HttpMessage> implements Ht
                 buffer.writeLine(this.lineBuf);
             }
         }
+        addTrailerHeader(buffer, message);
         this.lineBuf.clear();
         buffer.writeLine(this.lineBuf);
     }
 
+    protected void addTrailerHeader(final SessionOutputBuffer buffer, final T message)
+            throws IOException {}
 }

--- a/httpcore/src/main/java/org/apache/http/impl/io/ChunkedOutputStream.java
+++ b/httpcore/src/main/java/org/apache/http/impl/io/ChunkedOutputStream.java
@@ -29,7 +29,13 @@ package org.apache.http.impl.io;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Collections;
+import java.util.Set;
 
+import org.apache.http.EmptyTrailerSupplier;
+import org.apache.http.Header;
+import org.apache.http.ProtocolException;
+import org.apache.http.TrailerSupplier;
 import org.apache.http.annotation.NotThreadSafe;
 import org.apache.http.io.SessionOutputBuffer;
 import org.apache.http.util.CharArrayBuffer;
@@ -63,6 +69,10 @@ public class ChunkedOutputStream extends OutputStream {
 
     private final CharArrayBuffer linebuffer;
 
+    private final TrailerSupplier trailingHeaders;
+
+    private final Set<String> expectedTrailerNames;
+
     /**
      * Wraps a session output buffer and chunk-encodes the output.
      *
@@ -70,10 +80,20 @@ public class ChunkedOutputStream extends OutputStream {
      * @param out The session output buffer
      */
     public ChunkedOutputStream(final int bufferSize, final SessionOutputBuffer out) {
+        this(bufferSize, out, EmptyTrailerSupplier.instance,
+                Collections.<String>emptySet());
+    }
+
+    public ChunkedOutputStream(final int bufferSize,
+                               final SessionOutputBuffer out,
+                               final TrailerSupplier trailerHeaders,
+                               final Set<String> expectedTrailerNames) {
         super();
         this.cache = new byte[bufferSize];
         this.out = out;
         this.linebuffer = new CharArrayBuffer(32);
+        this.trailingHeaders = trailerHeaders;
+        this.expectedTrailerNames = expectedTrailerNames;
     }
 
     /**
@@ -111,8 +131,24 @@ public class ChunkedOutputStream extends OutputStream {
         this.linebuffer.clear();
         this.linebuffer.append('0');
         this.out.writeLine(this.linebuffer);
+        writeTrailers();
         this.linebuffer.clear();
         this.out.writeLine(this.linebuffer);
+    }
+
+    private void writeTrailers() throws IOException {
+        for (Header header : trailingHeaders.get()) {
+            this.linebuffer.clear();
+            if (expectedTrailerNames.contains(header.getName())) {
+                this.linebuffer.append(header.getName());
+                this.linebuffer.append(": ");
+                this.linebuffer.append(header.getValue());
+                this.out.writeLine(this.linebuffer);
+            } else {
+                throw new IOException(new ProtocolException("Unexpected trailer header: "
+                        + header.getName()));
+            }
+        }
     }
 
     // ----------------------------------------------------------- Public Methods

--- a/httpcore/src/main/java/org/apache/http/impl/io/DefaultHttpRequestWriter.java
+++ b/httpcore/src/main/java/org/apache/http/impl/io/DefaultHttpRequestWriter.java
@@ -27,10 +27,17 @@
 
 package org.apache.http.impl.io;
 
-import java.io.IOException;
+import static org.apache.http.util.TextUtils.join;
 
+import java.io.IOException;
+import java.util.Set;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpRequest;
 import org.apache.http.annotation.NotThreadSafe;
+import org.apache.http.io.SessionOutputBuffer;
+import org.apache.http.message.BasicHeader;
 import org.apache.http.message.LineFormatter;
 import org.apache.http.util.CharArrayBuffer;
 
@@ -64,4 +71,20 @@ public class DefaultHttpRequestWriter extends AbstractMessageWriter<HttpRequest>
         getLineFormatter().formatRequestLine(lineBuf, message.getRequestLine());
     }
 
+    protected void addTrailerHeader(final SessionOutputBuffer buffer,
+                                    final HttpRequest message)
+            throws IOException {
+        final HttpEntity entity = message.getEntity();
+        if (entity == null) {
+            return;
+        }
+        final Set<String> trailerNames = entity.getExpectedTrailerNames();
+        if (trailerNames.isEmpty()) {
+            return;
+        }
+        this.lineBuf.clear();
+        lineFormatter.formatHeader(this.lineBuf,
+                new BasicHeader(HttpHeaders.TRAILER, join(", ", trailerNames)));
+        buffer.writeLine(this.lineBuf);
+    }
 }

--- a/httpcore/src/main/java/org/apache/http/util/TextUtils.java
+++ b/httpcore/src/main/java/org/apache/http/util/TextUtils.java
@@ -27,11 +27,13 @@
 
 package org.apache.http.util;
 
+import java.util.Collection;
+import java.util.Iterator;
+
 /**
  * @since 4.3
  */
 public final class TextUtils {
-
     /**
      * Returns true if the parameter is null or of zero length
      */
@@ -72,4 +74,18 @@ public final class TextUtils {
         return false;
     }
 
+    public static String join(final String separator,
+                              final Collection<String> collection) {
+        final Iterator<String> iterator = collection.iterator();
+        if (!iterator.hasNext()) {
+            return "";
+        }
+        final CharArrayBuffer valueBuffer = new CharArrayBuffer(128);
+        valueBuffer.append(iterator.next());
+        while (iterator.hasNext()) {
+            valueBuffer.append(separator);
+            valueBuffer.append(iterator.next());
+        }
+        return valueBuffer.toString();
+    }
 }


### PR DESCRIPTION
getExpectedTrailerNames is introduced in HttpEntity for composing Trailer header.