### PR TITLE
HTTPCORE-418: add constructor to HttpHost for hostname and scheme

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/HttpHost.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/HttpHost.java
@@ -99,6 +99,18 @@ public final class HttpHost implements Serializable {
     }
 
     /**
+     * Creates {@code HttpHost} instance with the given hostname and scheme and the default port for that scheme.
+     *
+     * @param hostname  the hostname (IP or DNS name)
+     * @param scheme    the name of the scheme.
+     *                  {@code null} indicates the
+     *                  {@link #DEFAULT_SCHEME_NAME default scheme}
+     */
+    public HttpHost(final String hostname, final String scheme) {
+        this(hostname, -1, scheme);
+    }
+
+    /**
      * Creates {@code HttpHost} instance from string. Text may not contain any blanks.
      *
      * @since 4.4

--- a/httpcore5/src/test/java/org/apache/hc/core5/http/TestHttpHost.java
+++ b/httpcore5/src/test/java/org/apache/hc/core5/http/TestHttpHost.java
@@ -60,6 +60,10 @@ public class TestHttpHost {
         Assert.assertEquals("somehost", host4.getHostName());
         Assert.assertEquals(443, host4.getPort());
         Assert.assertEquals("https", host4.getSchemeName());
+        final HttpHost host5 = new HttpHost("somehost", "https");
+        Assert.assertEquals("somehost", host5.getHostName());
+        Assert.assertEquals(-1, host5.getPort());
+        Assert.assertEquals("https", host5.getSchemeName());
         try {
             new HttpHost((String) null, -1, null);
             Assert.fail("IllegalArgumentException should have been thrown");


### PR DESCRIPTION
Add a new constructor that takes a hostname and port and uses the default port for that scheme.
