### PR TITLE
Fix race condition in org.apache.http.nio.protocol.HttpAsyncRequestExecutor.endOfInput and org.apache.http.impl.nio.client.AbstractClientExchangeHandler.connectionAllocated(conn)

### DIFF
--- a/httpcore-nio/src/main/java/org/apache/http/nio/protocol/HttpAsyncRequestExecutor.java
+++ b/httpcore-nio/src/main/java/org/apache/http/nio/protocol/HttpAsyncRequestExecutor.java
@@ -396,11 +396,11 @@ public class HttpAsyncRequestExecutor implements NHttpClientEventHandler {
         this.exceptionLogger.log(ex);
     }
 
-    private State getState(final NHttpConnection conn) {
+    private static State getState(final NHttpConnection conn) {
         return (State) conn.getContext().getAttribute(HTTP_EXCHANGE_STATE);
     }
 
-    private HttpAsyncClientExchangeHandler getHandler(final NHttpConnection conn) {
+    private static HttpAsyncClientExchangeHandler getHandler(final NHttpConnection conn) {
         return (HttpAsyncClientExchangeHandler) conn.getContext().getAttribute(HTTP_HANDLER);
     }
 


### PR DESCRIPTION
Got pretty bad race condition when sending async requests.
Symptoms & Environment: We have target host which sometimes closes connections after requests processing but no `Connection: close` header was set. Some requests hangs, i.e. `BasicFuture` methods `.cancelled`, `.completed` or `.failed` methods are never called.

Analysis:
Let there be two threads:
- T1 is the async client reactor thread.
- T2 is the thread that initiates HTTP request.

T1: completes HTTP request and calls `connmgr.releaseConnection`
T2: initiates HTTP requests asks connmgr for connection and immediately gets connection that was just released by T1
T1: receives EOF on released connection and falls into `HttpAsyncRequestExecutor.endOfInput`. Connection has valid `HTTP_EXCHANGE_STATE`, but `HTTP_HANDLER` is null
T2: sets `HTTP_HANDLER`, requests output and checks `.isState`. Everything is OK here.
T1: goes to the end of `.endOfInput` and closes connection. `HTTP_HANDLER` is not null anymore, but is won't be notified about connection close, soon connection will be garbage collected and it will never be released and `HTTP_HANDLER.basicFuture` will never be notified.

Suggested fix (not sure if it is optimal, but it changed behaviour to be more redundant):
At the start of `.endOfInput` try to notify `HTTP_HANDLER`. If there is no one, set variable `handlerNotified` to false.
After connection close check `handlerNotified` and if it wasn't, then check if somebody has set `HTTP_HANDLER` externally.