### PR TITLE
Code quality fix - Useless parentheses around expressions should be removed to prevent any misunderstanding.

### DIFF
--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/hpack/HuffmanEncoder.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/hpack/HuffmanEncoder.java
@@ -61,7 +61,7 @@ final class HuffmanEncoder {
 
             while (n >= 8) {
                 n -= 8;
-                out.append(((int)(current >> n)));
+                out.append((int)(current >> n));
             }
         }
 
@@ -88,7 +88,7 @@ final class HuffmanEncoder {
 
             while (n >= 8) {
                 n -= 8;
-                out.append(((int)(current >> n)));
+                out.append((int)(current >> n));
             }
         }
 

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/io/SessionInputBufferImpl.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/impl/io/SessionInputBufferImpl.java
@@ -116,7 +116,7 @@ public class SessionInputBufferImpl implements SessionInputBuffer {
         } else {
             fillBuffer(instream, FrameConsts.HEAD_LEN + 1);
             payloadOff = FrameConsts.HEAD_LEN + 1;
-            padding = (buffer[off + 9] & 0xff);
+            padding = buffer[off + 9] & 0xff;
         }
 
         final int frameLen = payloadOff + payloadLen + padding;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/ProtocolVersion.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/ProtocolVersion.java
@@ -161,9 +161,9 @@ public class ProtocolVersion implements Serializable {
         }
         final ProtocolVersion that = (ProtocolVersion) obj;
 
-        return ((this.protocol.equals(that.protocol)) &&
-                (this.major == that.major) &&
-                (this.minor == that.minor));
+        return (this.protocol.equals(that.protocol) &&
+               (this.major == that.major) &&
+               (this.minor == that.minor));
     }
 
 

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHeaderIterator.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHeaderIterator.java
@@ -115,7 +115,7 @@ public class BasicHeaderIterator implements Iterator<Header> {
 
     @Override
     public boolean hasNext() {
-        return (this.currentIndex >= 0);
+        return this.currentIndex >= 0;
     }
 
     /**

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicListHeaderIterator.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicListHeaderIterator.java
@@ -128,7 +128,7 @@ class BasicListHeaderIterator implements Iterator<Header> {
 
     @Override
     public boolean hasNext() {
-        return (this.currentIndex >= 0);
+        return this.currentIndex >= 0;
     }
 
     /**

--- a/httpcore5/src/main/java/org/apache/hc/core5/reactor/IOSessionImpl.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/reactor/IOSessionImpl.java
@@ -322,7 +322,7 @@ public class IOSessionImpl implements IOSession, SocketAccessor {
 
     private static void formatAddress(final StringBuilder buffer, final SocketAddress socketAddress) {
         if (socketAddress instanceof InetSocketAddress) {
-            final InetSocketAddress addr = ((InetSocketAddress) socketAddress);
+            final InetSocketAddress addr = (InetSocketAddress) socketAddress;
             buffer.append(addr.getAddress() != null ? addr.getAddress().getHostAddress() :
                 addr.getAddress())
             .append(':')

--- a/httpcore5/src/main/java/org/apache/hc/core5/util/NetUtils.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/util/NetUtils.java
@@ -42,7 +42,7 @@ public final class NetUtils {
         Args.notNull(buffer, "Buffer");
         Args.notNull(socketAddress, "Socket address");
         if (socketAddress instanceof InetSocketAddress) {
-            final InetSocketAddress socketaddr = ((InetSocketAddress) socketAddress);
+            final InetSocketAddress socketaddr = (InetSocketAddress) socketAddress;
             final InetAddress inetaddr = socketaddr.getAddress();
             buffer.append(inetaddr != null ? inetaddr.getHostAddress() : inetaddr)
                 .append(':').append(socketaddr.getPort());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.

Faisal Hameed