### PR TITLE
Code quality fix - Array designators "[]" should be on the type, not the variable

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ChunkedInputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ChunkedInputStream.java
@@ -309,7 +309,7 @@ public class ChunkedInputStream extends InputStream {
             try {
                 if (!eof && state != CHUNK_INVALID) {
                     // read and discard the remainder of the message
-                    final byte buff[] = new byte[BUFFER_SIZE];
+                    final byte[] buff = new byte[BUFFER_SIZE];
                     while (read(buff) >= 0) {
                     }
                 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ChunkedOutputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ChunkedOutputStream.java
@@ -113,7 +113,7 @@ public class ChunkedOutputStream extends OutputStream {
      * Writes the cache and bufferToAppend to the underlying stream
      * as one large chunk
      */
-    private void flushCacheWithAppend(final byte bufferToAppend[], final int off, final int len) throws IOException {
+    private void flushCacheWithAppend(final byte[] bufferToAppend, final int off, final int len) throws IOException {
         this.lineBuffer.clear();
         this.lineBuffer.append(Integer.toHexString(this.cachePosition + len));
         this.buffer.writeLine(this.lineBuffer, this.outputStream);
@@ -182,7 +182,7 @@ public class ChunkedOutputStream extends OutputStream {
      * not split, but rather written out as one large chunk.
      */
     @Override
-    public void write(final byte b[]) throws IOException {
+    public void write(final byte[] b) throws IOException {
         write(b, 0, b.length);
     }
 
@@ -191,7 +191,7 @@ public class ChunkedOutputStream extends OutputStream {
      * not split, but rather written out as one large chunk.
      */
     @Override
-    public void write(final byte src[], final int off, final int len) throws IOException {
+    public void write(final byte[] src, final int off, final int len) throws IOException {
         if (this.closed) {
             throw new IOException("Attempted write to closed stream.");
         }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ContentLengthInputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/ContentLengthInputStream.java
@@ -98,7 +98,7 @@ public class ContentLengthInputStream extends InputStream {
         if (!closed) {
             try {
                 if (pos < contentLength) {
-                    final byte buffer[] = new byte[BUFFER_SIZE];
+                    final byte[] buffer = new byte[BUFFER_SIZE];
                     while (read(buffer) >= 0) {
                     }
                 }

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/ContentInputStream.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/nio/entity/ContentInputStream.java
@@ -76,7 +76,7 @@ public class ContentInputStream extends InputStream {
     @Override
     public void close() throws IOException {
         // read and discard the remainder of the message
-        final byte tmp[] = new byte[1024];
+        final byte[] tmp = new byte[1024];
         while (this.buffer.read(tmp, 0, tmp.length) >= 0) {
         }
         super.close();

--- a/httpcore5/src/main/java/org/apache/hc/core5/util/ByteArrayBuffer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/util/ByteArrayBuffer.java
@@ -57,7 +57,7 @@ public final class ByteArrayBuffer implements Serializable {
     }
 
     private void expand(final int newlen) {
-        final byte newbuffer[] = new byte[Math.max(this.buffer.length << 1, newlen)];
+        final byte[] newbuffer = new byte[Math.max(this.buffer.length << 1, newlen)];
         System.arraycopy(this.buffer, 0, newbuffer, 0, this.len);
         this.buffer = newbuffer;
     }

--- a/httpcore5/src/main/java/org/apache/hc/core5/util/CharArrayBuffer.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/util/CharArrayBuffer.java
@@ -59,7 +59,7 @@ public final class CharArrayBuffer implements CharSequence, Serializable {
     }
 
     private void expand(final int newlen) {
-        final char newbuffer[] = new char[Math.max(this.buffer.length << 1, newlen)];
+        final char[] newbuffer = new char[Math.max(this.buffer.length << 1, newlen)];
         System.arraycopy(this.buffer, 0, newbuffer, 0, this.len);
         this.buffer = newbuffer;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1197 - Array designators "[]" should be on the type, not the variable.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1197

Please let me know if you have any questions.

Faisal Hameed