### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/httpcore5-ab/src/main/java/org/apache/hc/core5/http/benchmark/CommandLineUtils.java
+++ b/httpcore5-ab/src/main/java/org/apache/hc/core5/http/benchmark/CommandLineUtils.java
@@ -37,6 +37,9 @@ import org.apache.commons.cli.Options;
 
 public class CommandLineUtils {
 
+    private CommandLineUtils() {
+        // Do not allow utility class to be instantiated.
+    }
     public static Options getOptions() {
         final Option iopt = new Option("i", false, "Do HEAD requests instead of GET (deprecated)");
         iopt.setRequired(false);

--- a/httpcore5-ab/src/main/java/org/apache/hc/core5/http/benchmark/ResultProcessor.java
+++ b/httpcore5-ab/src/main/java/org/apache/hc/core5/http/benchmark/ResultProcessor.java
@@ -32,6 +32,9 @@ import org.apache.hc.core5.http.HttpHost;
 
 public class ResultProcessor {
 
+    private ResultProcessor() {
+        // Do not allow utility class to be instantiated.
+    }
     static NumberFormat nf2 = NumberFormat.getInstance();
     static NumberFormat nf3 = NumberFormat.getInstance();
     static NumberFormat nf6 = NumberFormat.getInstance();

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/frame/FrameConsts.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/frame/FrameConsts.java
@@ -28,6 +28,9 @@ package org.apache.hc.core5.http2.frame;
 
 public final class FrameConsts {
 
+    private FrameConsts() {
+        // Do not allow utility class to be instantiated.
+    }
     public final static int HEAD_LEN = 9;
     public final static int MAX_PADDING = 255;
 

--- a/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/hpack/Huffman.java
+++ b/httpcore5-h2/src/main/java/org/apache/hc/core5/http2/hpack/Huffman.java
@@ -33,6 +33,9 @@ package org.apache.hc.core5.http2.hpack;
  */
 public final class Huffman {
 
+    private Huffman() {
+        // Do not allow utility class to be instantiated.
+    }
     static final int[] CODES = {
             0x1ff8,
             0x7fffd8,

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/ConnSupport.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/ConnSupport.java
@@ -40,6 +40,9 @@ import org.apache.hc.core5.http.config.ConnectionConfig;
  */
 public final class ConnSupport {
 
+    private ConnSupport() {
+        // Do not allow utility class to be instantiated.
+    }
     public static CharsetDecoder createDecoder(final ConnectionConfig cconfig) {
         if (cconfig == null) {
             return null;

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/TrailerNameFormatter.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/protocol/TrailerNameFormatter.java
@@ -45,6 +45,9 @@ import org.apache.hc.core5.util.CharArrayBuffer;
  */
 public class TrailerNameFormatter {
 
+    private TrailerNameFormatter() {
+        // Do not allow utility class to be instantiated.
+    }
     public static Header format(final HttpEntity entity) {
         if (entity == null) {
             return null;

--- a/httpcore5/src/main/java/org/apache/hc/core5/ssl/SSLContexts.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/ssl/SSLContexts.java
@@ -51,6 +51,9 @@ import org.apache.hc.core5.annotation.Immutable;
 @Immutable
 public class SSLContexts {
 
+    private SSLContexts() {
+        // Do not allow utility class to be instantiated.
+    }
     /**
      * Creates default factory based on the standard JSSE trust material
      * ({@code cacerts} file in the security properties directory). System properties

--- a/httpcore5/src/main/java/org/apache/hc/core5/util/Args.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/util/Args.java
@@ -31,6 +31,9 @@ import java.util.Collection;
 
 public class Args {
 
+    private Args() {
+        // Do not allow utility class to be instantiated.
+    }
     public static void check(final boolean expression, final String message) {
         if (!expression) {
             throw new IllegalArgumentException(message);

--- a/httpcore5/src/main/java/org/apache/hc/core5/util/Asserts.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/util/Asserts.java
@@ -29,6 +29,9 @@ package org.apache.hc.core5.util;
 
 public class Asserts {
 
+    private Asserts() {
+        // Do not allow utility class to be instantiated.
+    }
     public static void check(final boolean expression, final String message) {
         if (!expression) {
             throw new IllegalStateException(message);

--- a/httpcore5/src/main/java/org/apache/hc/core5/util/CharsetUtils.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/util/CharsetUtils.java
@@ -33,6 +33,9 @@ import java.nio.charset.UnsupportedCharsetException;
 
 public class CharsetUtils {
 
+    private CharsetUtils() {
+        // Do not allow utility class to be instantiated.
+    }
     public static Charset lookup(final String name) {
         if (name == null) {
             return null;

--- a/httpcore5/src/main/java/org/apache/hc/core5/util/NetUtils.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/util/NetUtils.java
@@ -36,6 +36,9 @@ import java.net.SocketAddress;
  */
 public final class NetUtils {
 
+    private NetUtils() {
+        // Do not allow utility class to be instantiated.
+    }
     public static void formatAddress(
             final StringBuilder buffer,
             final SocketAddress socketAddress) {

--- a/httpcore5/src/main/java/org/apache/hc/core5/util/TextUtils.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/util/TextUtils.java
@@ -32,6 +32,9 @@ package org.apache.hc.core5.util;
  */
 public final class TextUtils {
 
+    private TextUtils() {
+        // Do not allow utility class to be instantiated.
+    }
     /**
      * Returns true if the parameter is null or of zero length
      */


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed