### PR TITLE
General code quality fix-1

### DIFF
--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/HttpService.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/io/HttpService.java
@@ -168,7 +168,7 @@ public class HttpService {
         final Header expect = request.getFirstHeader(HttpHeaders.EXPECT);
         final boolean expectContinue = expect != null && "100-continue".equalsIgnoreCase(expect.getValue());
 
-        HttpResponse response = null;
+        HttpResponse response;
 
         if (expectContinue) {
             response = this.responseFactory.newHttpResponse(HttpStatus.SC_CONTINUE, context);

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/SSLNHttpClientConnectionFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/SSLNHttpClientConnectionFactory.java
@@ -146,9 +146,7 @@ public class SSLNHttpClientConnectionFactory
             final IOSession iosession,
             final SSLContext sslcontext,
             final SSLSetupHandler sslHandler) {
-        final SSLIOSession ssliosession = new SSLIOSession(iosession, SSLMode.CLIENT,
-                sslcontext, sslHandler);
-        return ssliosession;
+        return new SSLIOSession(iosession, SSLMode.CLIENT, sslcontext, sslHandler);
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/SSLNHttpServerConnectionFactory.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/impl/nio/SSLNHttpServerConnectionFactory.java
@@ -144,9 +144,7 @@ public class SSLNHttpServerConnectionFactory
             final IOSession iosession,
             final SSLContext sslcontext,
             final SSLSetupHandler sslHandler) {
-        final SSLIOSession ssliosession = new SSLIOSession(iosession, SSLMode.SERVER,
-                sslcontext, sslHandler);
-        return ssliosession;
+        return new SSLIOSession(iosession, SSLMode.SERVER, sslcontext, sslHandler);
     }
 
     @Override

--- a/httpcore5/src/main/java/org/apache/hc/core5/http/message/HeaderGroup.java
+++ b/httpcore5/src/main/java/org/apache/hc/core5/http/message/HeaderGroup.java
@@ -51,7 +51,7 @@ public class HeaderGroup implements Serializable {
 
     private static final long serialVersionUID = 2608834160639271617L;
 
-    private final Header[] EMPTY = new Header[] {};
+    private static final Header[] EMPTY = new Header[] {};
 
     /** The list of headers for this group, in the order in which they were added */
     private final List<Header> headers;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1854 - Dead stores should be removed. 
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
squid:S1170 - Public constants should be declared "static final" rather than merely "final". 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1488
https://dev.eclipse.org/sonar/rules/show/squid:S1170

Please let me know if you have any questions.

Faisal Hameed