### PR TITLE
Support 64-bit chunk headers

### DIFF
--- a/httpcore-nio/src/main/java/org/apache/http/impl/nio/codecs/ChunkDecoder.java
+++ b/httpcore-nio/src/main/java/org/apache/http/impl/nio/codecs/ChunkDecoder.java
@@ -65,8 +65,8 @@ public class ChunkDecoder extends AbstractContentDecoder {
     private boolean endOfStream;
 
     private CharArrayBuffer lineBuf;
-    private int chunkSize;
-    private int pos;
+    private long chunkSize;
+    private long pos;
 
     private final MessageConstraints constraints;
     private final List<CharArrayBuffer> trailerBufs;
@@ -83,8 +83,8 @@ public class ChunkDecoder extends AbstractContentDecoder {
             final HttpTransportMetricsImpl metrics) {
         super(channel, buffer, metrics);
         this.state = READ_CONTENT;
-        this.chunkSize = -1;
-        this.pos = 0;
+        this.chunkSize = -1L;
+        this.pos = 0L;
         this.endOfChunk = false;
         this.endOfStream = false;
         this.constraints = constraints != null ? constraints : MessageConstraints.DEFAULT;
@@ -129,13 +129,13 @@ public class ChunkDecoder extends AbstractContentDecoder {
             if (separator < 0) {
                 separator = this.lineBuf.length();
             }
+            final String s = this.lineBuf.substringTrimmed(0, separator);
             try {
-                final String s = this.lineBuf.substringTrimmed(0, separator);
-                this.chunkSize = Integer.parseInt(s, 16);
+                this.chunkSize = Long.parseLong(s, 16);
             } catch (final NumberFormatException e) {
-                throw new MalformedChunkCodingException("Bad chunk header");
+                throw new MalformedChunkCodingException("Bad chunk header: " + s);
             }
-            this.pos = 0;
+            this.pos = 0L;
         } else if (this.endOfStream) {
             throw new ConnectionClosedException("Premature end of chunk coded message body: " +
                     "closing chunk expected");
@@ -193,7 +193,7 @@ public class ChunkDecoder extends AbstractContentDecoder {
         int totalRead = 0;
         while (this.state != COMPLETED) {
 
-            if (!this.buffer.hasData() || this.chunkSize == -1) {
+            if (!this.buffer.hasData() || this.chunkSize == -1L) {
                 final int bytesRead = fillBufferFromChannel();
                 if (bytesRead == -1) {
                     this.endOfStream = true;
@@ -203,21 +203,21 @@ public class ChunkDecoder extends AbstractContentDecoder {
             switch (this.state) {
             case READ_CONTENT:
 
-                if (this.chunkSize == -1) {
+                if (this.chunkSize == -1L) {
                     readChunkHead();
-                    if (this.chunkSize == -1) {
+                    if (this.chunkSize == -1L) {
                         // Unable to read a chunk head
                         return totalRead;
                     }
-                    if (this.chunkSize == 0) {
+                    if (this.chunkSize == 0L) {
                         // Last chunk. Read footers
-                        this.chunkSize = -1;
+                        this.chunkSize = -1L;
                         this.state = READ_FOOTERS;
                         break;
                     }
                 }
-                final int maxLen = this.chunkSize - this.pos;
-                final int len = this.buffer.read(dst, maxLen);
+                final long maxLen = this.chunkSize - this.pos;
+                final int len = this.buffer.read(dst, (int) Math.min(maxLen, Integer.MAX_VALUE));
                 if (len > 0) {
                     this.pos += len;
                     totalRead += len;
@@ -233,8 +233,8 @@ public class ChunkDecoder extends AbstractContentDecoder {
 
                 if (this.pos == this.chunkSize) {
                     // At the end of the chunk
-                    this.chunkSize = -1;
-                    this.pos = 0;
+                    this.chunkSize = -1L;
+                    this.pos = 0L;
                     this.endOfChunk = true;
                     break;
                 }

--- a/httpcore-nio/src/test/java/org/apache/http/impl/nio/codecs/TestChunkDecoder.java
+++ b/httpcore-nio/src/test/java/org/apache/http/impl/nio/codecs/TestChunkDecoder.java
@@ -586,4 +586,24 @@ public class TestChunkDecoder {
         decoder.read(null);
     }
 
+    @Test
+    public void testHugeChunk() throws Exception {
+        final String s = "1234567890abcdef\r\n0123456789abcdef";
+        final ReadableByteChannel channel = new ReadableByteChannelMock(
+                new String[] {s}, Consts.ASCII);
+        final SessionInputBuffer inbuf = new SessionInputBufferImpl(1024, 256, Consts.ASCII);
+        final HttpTransportMetricsImpl metrics = new HttpTransportMetricsImpl();
+        final ChunkDecoder decoder = new ChunkDecoder(channel, inbuf, metrics);
+
+        final ByteBuffer dst = ByteBuffer.allocate(4);
+
+        int bytesRead = decoder.read(dst);
+        Assert.assertEquals(4, bytesRead);
+        Assert.assertEquals("0123", CodecTestUtils.convert(dst));
+        dst.clear();
+        bytesRead = decoder.read(dst);
+        Assert.assertEquals(4, bytesRead);
+        Assert.assertEquals("4567", CodecTestUtils.convert(dst));
+    }
+
 }

--- a/httpcore/src/test/java/org/apache/http/impl/io/TestChunkCoding.java
+++ b/httpcore/src/test/java/org/apache/http/impl/io/TestChunkCoding.java
@@ -506,5 +506,19 @@ public class TestChunkCoding {
         in.close();
 }
 
+    // Test for when buffer is larger than chunk size
+    @Test
+    public void testHugeChunk() throws IOException {
+        final ChunkedInputStream in = new ChunkedInputStream(
+                new SessionInputBufferMock("1234567890abcdef\r\n01234567", Consts.ISO_8859_1));
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        for (int i = 0; i < 8; ++i) {
+            out.write(in.read());
+        }
+
+        final String result = new String(out.toByteArray(), Consts.ISO_8859_1);
+        Assert.assertEquals("01234567", result);
+    }
+
 }
 


### PR DESCRIPTION
Some caching servers (like nginx) doesn't send Content-Length for cached responses from upstream which returned chunked response. The only way to ensure response completeness is to use chunked encoding.
Unfortunately, nginx sends whole response in single chunk, so chunk header will contain file size, which can be greater than Integer.MAX_VALUE (however, still can be processed by ZeroCopyConsumer).

Proposed patch contains changes for huge chunks processing. New unit-tests included.