### PR TITLE
Fixed copy-paste mistake in JavaDoc

### DIFF
--- a/httpcore/src/main/java/org/apache/http/entity/AbstractHttpEntity.java
+++ b/httpcore/src/main/java/org/apache/http/entity/AbstractHttpEntity.java
@@ -104,7 +104,7 @@ public abstract class AbstractHttpEntity implements HttpEntity {
      * The default implementation sets the value of the
      * {@link #contentType contentType} attribute.
      *
-     * @param contentType       the new Content-Encoding header, or
+     * @param contentType       the new Content-Type header, or
      *                          <code>null</code> to unset
      */
     public void setContentType(final Header contentType) {


### PR DESCRIPTION
setContentType() method JavaDoc mentions "Content-Encoding" header name, not "Content-Type".