### PR TITLE
HTTPCORE-431 Fix EntityUtils encoding for application/json

### DIFF
--- a/httpcore/src/main/java/org/apache/http/Consts.java
+++ b/httpcore/src/main/java/org/apache/http/Consts.java
@@ -42,6 +42,8 @@ public final class Consts {
     public static final int HT = 9;  // <US-ASCII HT, horizontal-tab (9)>
 
     public static final Charset UTF_8 = Charset.forName("UTF-8");
+    public static final Charset UTF_16 = Charset.forName("UTF-16");
+    public static final Charset UTF_32 = Charset.forName("UTF-32");
     public static final Charset ASCII = Charset.forName("US-ASCII");
     public static final Charset ISO_8859_1 = Charset.forName("ISO-8859-1");
 

--- a/httpcore/src/test/java/org/apache/http/util/TestEntityUtils.java
+++ b/httpcore/src/test/java/org/apache/http/util/TestEntityUtils.java
@@ -215,6 +215,110 @@ public class TestEntityUtils {
         Assert.assertEquals(content, s);
     }
 
+    @Test
+    public void testUtf8JsonToString() throws Exception {
+        final BasicHttpEntity httpentity = new BasicHttpEntity();
+        httpentity.setContent(new ByteArrayInputStream(new byte[] {
+                (byte)0x22, (byte)0xc2, (byte)0xa7, (byte)0x22
+        }));
+        httpentity.setContentType("application/json");
+        final String s = EntityUtils.toString(httpentity);
+        Assert.assertEquals("\"\u00a7\"", s);
+    }
+
+    @Test
+    public void testUtf8BomJsonToString() throws Exception {
+        final BasicHttpEntity httpentity = new BasicHttpEntity();
+        httpentity.setContent(new ByteArrayInputStream(new byte[] {
+                (byte)0xef, (byte)0xbb, (byte)0xbf, (byte)0x22, (byte)0xc2, (byte)0xa7, (byte)0x22
+        }));
+        httpentity.setContentType("application/json");
+        final String s = EntityUtils.toString(httpentity);
+        Assert.assertEquals("\"\u00a7\"", s);
+    }
+
+    @Test
+    public void testUtf16JsonToString() throws Exception {
+        final BasicHttpEntity httpentity = new BasicHttpEntity();
+        httpentity.setContent(new ByteArrayInputStream(new byte[] {
+                (byte)0x00, (byte)0x22,
+                (byte)0x00, (byte)0xa7,
+                (byte)0x00, (byte)0x22
+        }));
+        httpentity.setContentType("application/json");
+        final String s = EntityUtils.toString(httpentity);
+        Assert.assertEquals("\"\u00a7\"", s);
+    }
+
+    @Test
+    public void testUtf16BeJsonToString() throws Exception {
+        final BasicHttpEntity httpentity = new BasicHttpEntity();
+        httpentity.setContent(new ByteArrayInputStream(new byte[] {
+                (byte)0xfe, (byte)0xff,
+                (byte)0x00, (byte)0x22,
+                (byte)0x00, (byte)0xa7,
+                (byte)0x00, (byte)0x22
+        }));
+        httpentity.setContentType("application/json");
+        final String s = EntityUtils.toString(httpentity);
+        Assert.assertEquals("\"\u00a7\"", s);
+    }
+
+    @Test
+    public void testUtf16LeJsonToString() throws Exception {
+        final BasicHttpEntity httpentity = new BasicHttpEntity();
+        httpentity.setContent(new ByteArrayInputStream(new byte[] {
+                (byte)0xff, (byte)0xfe,
+                (byte)0x22, (byte)0x00,
+                (byte)0xa7, (byte)0x00,
+                (byte)0x22, (byte)0x00
+        }));
+        httpentity.setContentType("application/json");
+        final String s = EntityUtils.toString(httpentity);
+        Assert.assertEquals("\"\u00a7\"", s);
+    }
+
+    @Test
+    public void testUtf32JsonToString() throws Exception {
+        final BasicHttpEntity httpentity = new BasicHttpEntity();
+        httpentity.setContent(new ByteArrayInputStream(new byte[] {
+                (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x22,
+                (byte)0x00, (byte)0x00, (byte)0x00, (byte)0xa7,
+                (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x22
+        }));
+        httpentity.setContentType("application/json");
+        final String s = EntityUtils.toString(httpentity);
+        Assert.assertEquals("\"\u00a7\"", s);
+    }
+
+    @Test
+    public void testUtf32BeJsonToString() throws Exception {
+        final BasicHttpEntity httpentity = new BasicHttpEntity();
+        httpentity.setContent(new ByteArrayInputStream(new byte[] {
+                (byte)0x00, (byte)0x00, (byte)0xfe, (byte)0xff,
+                (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x22,
+                (byte)0x00, (byte)0x00, (byte)0x00, (byte)0xa7,
+                (byte)0x00, (byte)0x00, (byte)0x00, (byte)0x22
+        }));
+        httpentity.setContentType("application/json");
+        final String s = EntityUtils.toString(httpentity);
+        Assert.assertEquals("\"\u00a7\"", s);
+    }
+
+    @Test
+    public void testUtf32LeJsonToString() throws Exception {
+        final BasicHttpEntity httpentity = new BasicHttpEntity();
+        httpentity.setContent(new ByteArrayInputStream(new byte[] {
+                (byte)0xff, (byte)0xfe, (byte)0x00, (byte)0x00,
+                (byte)0x22, (byte)0x00, (byte)0x00, (byte)0x00,
+                (byte)0xa7, (byte)0x00, (byte)0x00, (byte)0x00,
+                (byte)0x22, (byte)0x00, (byte)0x00, (byte)0x00
+        }));
+        httpentity.setContentType("application/json");
+        final String s = EntityUtils.toString(httpentity);
+        Assert.assertEquals("\"\u00a7\"", s);
+    }
+
     /**
      * Helper class that returns {@code null} as the content.
      */


### PR DESCRIPTION
Auto-detect UTF encoding as described in RFC 4627/7159, including BOM handling