### PR TITLE
Restoring documentation removed from testing.framework classes.

### DIFF
--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/framework/ClassicTestClientAdapter.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/framework/ClassicTestClientAdapter.java
@@ -45,6 +45,11 @@ import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
 import org.apache.hc.core5.http.protocol.HttpCoreContext;
 import org.apache.hc.core5.testing.classic.ClassicTestClient;
 
+/**
+ * Implementation of {@link ClientPOJOAdapter} for ClassicTestClient.
+ *
+ * @since 5.0
+ */
 public class ClassicTestClientAdapter extends ClientPOJOAdapter {
 
     /**

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/framework/ClassicTestClientTestingAdapter.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/framework/ClassicTestClientTestingAdapter.java
@@ -27,6 +27,11 @@
 
 package org.apache.hc.core5.testing.framework;
 
+/**
+ * Implementation of {@link ClientTestingAdapter} for the ClassicTestClient.
+ *
+ * @since 5.0
+ */
 public class ClassicTestClientTestingAdapter extends ClientTestingAdapter {
 
     public ClassicTestClientTestingAdapter() {

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/framework/ClientTestingAdapter.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/framework/ClientTestingAdapter.java
@@ -29,6 +29,35 @@ package org.apache.hc.core5.testing.framework;
 
 import java.util.Map;
 
+/**
+*
+* <p>This adapter assists the testing of an HTTP client.  This adapter in turn uses an
+* {@link ClientPOJOAdapter} to actually use the HTTP client to make the request.
+* See {@link ClientPOJOAdapter} to see the format of the request and the returned
+* response.  The format of the returned response is also the format of the parameter
+* called responseExpectations.</p>
+*
+* <p>This adapter will generally call the {@link ClientPOJOAdapter} methods of the same
+* name when these methods are called:</p>
+*
+* <pre>
+*
+* isRequestSupported
+* modifyRequest
+* execute
+*
+* </pre>
+*
+* <p>See these method's documentation in {@link ClientPOJOAdapter} for details.</p>
+*
+* <p>The value that this adapter adds is with the modifyResponseExpectations method.  Each
+* test will specify the response that is expected.  The HttpClient5 adapter is able
+* to use these unmodified expectations, but if a different HTTP client (such as Groovy's
+* RESTClient which uses HttpClient) for some reason needs to modify the expectations,
+* it would be done in the modifyResponseExpectations method.</p>
+*
+* @since 5.0
+*/
 public class ClientTestingAdapter {
     /**
      * This adapter will perform the HTTP request and return the response in the

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/framework/FrameworkTest.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/framework/FrameworkTest.java
@@ -48,6 +48,20 @@ import java.util.Map;
 import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.net.URLEncodedUtils;
 
+/**
+ * <p>This class is not expected to be used directly by the user, but its job is to
+ * supply helpful defaults for tests.</p>
+ *
+ * <p>A test is made up of an HTTP request that the HTTP client will send as well
+ * as a response that is expected.</p>
+ *
+ * <p>See {@link ClientPOJOAdapter} for details on the request and response.</p>
+ *
+ * <p>Generally, if the request does not specify a method, it is assumed to be a GET.
+ * There are also defaults for headers, query parameters, body, contentType, etc.</p>
+ *
+ * @since 5.0
+ */
 public class FrameworkTest {
 
     private Map<String, Object> request = new HashMap<>();

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/framework/TestingFramework.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/framework/TestingFramework.java
@@ -54,6 +54,47 @@ import org.apache.hc.core5.http.config.SocketConfig;
 import org.apache.hc.core5.http.impl.io.bootstrap.HttpServer;
 import org.apache.hc.core5.http.impl.io.bootstrap.ServerBootstrap;
 
+/**
+ * <p>This testing framework starts an in-process {@link HttpServer} which will use an
+ * {@link TestingFrameworkRequestHandler} to check HTTP requests that are sent
+ * to it.  Before the request is sent, the handler is told what request to expect.
+ * If the received request does not match the request expectations, an exception
+ * is thrown.</p>
+ *
+ * <p>The handler is also told what response to return.  This testing framework will
+ * then check the response it receives with what it desired.  If they do not
+ * match, an exception is thrown.</p>
+ *
+ * <p>This has been designed to work with any HTTP client.  So, for instance, Groovy's
+ * HttpBuilder or RESTClient which uses Apache HttpClient can also be tested with this
+ * testing framework.  A different {@link ClientTestingAdapter} is used with
+ * different HTTP clients.  If testing Apache HttpClient5, the {@link ClassicTestClientTestingAdapter}
+ * is used.  Since use of this testing framework with other projects is desired,
+ * the testframework package has been placed outside the test directory.  Care has
+ * been taken to make sure no testing dependency such as JUnit or EasyMock is used
+ * in the framework.</p>
+ *
+ * <p>The {@link ClassicTestClientTestingAdapter} that is used is either passed into the
+ * constructor or set with setAdapter().</p>
+ *
+ * <p>By default, this framework will go through a series of tests that will exercise
+ * all HTTP methods.  If the default tests are not desired, then the deleteTests()
+ * method can be called.  Then, custom tests can be added with the addTest() methods.
+ * Of course additional tests can be added with the addTest() method without first
+ * calling deleteTests().  In that case, the default tests and the additional tests
+ * will all run.</p>
+ *
+ * <p>Since this framework has been designed to be used with any HTTP client, the test
+ * is specified with POJO's such as Map, List, and primitives.  The test is a Map with
+ * two keys - request and response.  See {@link ClientPOJOAdapter} for details
+ * on the format of the request and response.</p>
+ *
+ * <p>Once any additional tests have been added, the runTests() method is called to
+ * actually do the testing.</p>
+ *
+ * @since 5.0
+ *
+ */
 public class TestingFramework {
     /**
      * Use the ALL_METHODS list to conveniently cycle through all HTTP methods.

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/framework/TestingFrameworkException.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/framework/TestingFrameworkException.java
@@ -27,6 +27,15 @@
 
 package org.apache.hc.core5.testing.framework;
 
+/**
+ * <p>Signals a problem or an assertion failure while using the {@link TestingFramework}.</p>
+ *
+ * <p>Optionally, an adapter and a test can be added to the exception.  If this is done,
+ * the adapter name and the test information is appended to the exception message to help
+ * determine what test is having a problem.</p>
+ *
+ * @since 5.0
+ */
 public class TestingFrameworkException extends Exception {
     public static final String NO_HTTP_CLIENT = "none";
 

--- a/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/framework/TestingFrameworkRequestHandler.java
+++ b/httpcore5-testing/src/main/java/org/apache/hc/core5/testing/framework/TestingFrameworkRequestHandler.java
@@ -57,6 +57,20 @@ import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.net.URLEncodedUtils;
 
+/**
+ * <p>This request handler is used with an in-process instance of HttpServer during testing.
+ * The handler is told what to expect in the request.  If the request does not match
+ * the expectations, the handler will throw an exception which is then caught and
+ * saved in the "thrown" member.  The testing framework will later call assertNothingThrown().
+ * If something was thrown earlier by the handler, an exception will be thrown by the method.</p>
+ *
+ * <p>The handler is also told what response to return.</p>
+ *
+ * <p>See {@link ClientPOJOAdapter} for details on the format of the request and response.</p>
+ *
+ * @since 5.0
+ *
+ */
 public class TestingFrameworkRequestHandler implements HttpRequestHandler {
     protected Throwable thrown;
     protected Map<String, Object> requestExpectations;


### PR DESCRIPTION
If this documentation was removed deliberately, then that is OK I guess, but just in case it was removed by mistake, I have created this pull request to restore it.