### PR TITLE
Adding extra argument support for httpcore5-ab: TimeLimit

### DIFF
--- a/httpcore5-ab/src/main/java/org/apache/hc/core5/http/benchmark/BenchmarkWorker.java
+++ b/httpcore5-ab/src/main/java/org/apache/hc/core5/http/benchmark/BenchmarkWorker.java
@@ -76,6 +76,7 @@ class BenchmarkWorker implements Runnable {
     private final ClassicHttpRequest request;
     private final Config config;
     private final SocketFactory socketFactory;
+    private boolean shutdownSignal;
     private final Stats stats = new Stats();
 
     public BenchmarkWorker(
@@ -102,6 +103,7 @@ class BenchmarkWorker implements Runnable {
 
         this.connstrategy = DefaultConnectionReuseStrategy.INSTANCE;
         this.socketFactory = socketFactory;
+        this.shutdownSignal = false;
     }
 
     @Override
@@ -215,6 +217,7 @@ class BenchmarkWorker implements Runnable {
                 }
             }
 
+            if (shutdownSignal) break;
         }
         stats.finish();
 
@@ -268,5 +271,9 @@ class BenchmarkWorker implements Runnable {
 
     public Stats getStats() {
         return stats;
+    }
+
+    public synchronized void setShutdownSignal() {
+        this.shutdownSignal = true;
     }
 }

--- a/httpcore5-ab/src/main/java/org/apache/hc/core5/http/benchmark/CommandLineUtils.java
+++ b/httpcore5-ab/src/main/java/org/apache/hc/core5/http/benchmark/CommandLineUtils.java
@@ -91,6 +91,10 @@ public class CommandLineUtils {
         topt.setRequired(false);
         topt.setArgName("socket-Timeout");
 
+        final Option tlopt = new Option("l", true, "Time limit for the test to run (default is infinity)");
+        tlopt.setRequired(false);
+        tlopt.setArgName("time-limit");
+
         final Option Hopt = new Option("H", true, "Add arbitrary header line, " +
             "eg. 'Accept-Encoding: gzip' inserted after all normal " +
             "header lines. (repeatable as -H \"h1: v1\",\"h2: v2\" etc)");
@@ -123,6 +127,7 @@ public class CommandLineUtils {
         options.addOption(hopt);
         options.addOption(topt);
         options.addOption(oopt);
+        options.addOption(tlopt);
         return options;
     }
 
@@ -185,6 +190,15 @@ public class CommandLineUtils {
                 config.setSocketTimeout(Integer.parseInt(t));
             } catch (final NumberFormatException ex) {
                 printError("Invalid socket timeout: " + t);
+            }
+        }
+
+        if (cmd.hasOption('l')) {
+            final String l = cmd.getOptionValue('l');
+            try {
+                config.setTimeLimit(Integer.parseInt(l));
+            } catch (final NumberFormatException ex) {
+                printError("Invalid time limit: " + l);
             }
         }
 

--- a/httpcore5-ab/src/main/java/org/apache/hc/core5/http/benchmark/Config.java
+++ b/httpcore5-ab/src/main/java/org/apache/hc/core5/http/benchmark/Config.java
@@ -48,6 +48,7 @@ public class Config {
     private File payloadFile = null;
     private String payloadText = null;
     private String soapAction = null;
+    private int timeLimit = -1;
 
     private boolean disableSSLVerification = true;
     private String trustStorePath = null;
@@ -246,6 +247,14 @@ public class Config {
 
     public void setIdentityStorePassword(final String identityStorePassword) {
         this.identityStorePassword = identityStorePassword;
+    }
+
+    public void setTimeLimit(final int timeLimit) {
+        this.timeLimit = timeLimit;
+    }
+
+    public int getTimeLimit() {
+        return timeLimit;
     }
 
     public Config copy() {

--- a/httpcore5-ab/src/main/java/org/apache/hc/core5/http/benchmark/HttpBenchmark.java
+++ b/httpcore5-ab/src/main/java/org/apache/hc/core5/http/benchmark/HttpBenchmark.java
@@ -26,18 +26,6 @@
  */
 package org.apache.hc.core5.http.benchmark;
 
-import java.io.File;
-import java.net.URL;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-
-import javax.net.SocketFactory;
-import javax.net.ssl.SSLContext;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.Options;
@@ -56,6 +44,17 @@ import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
 import org.apache.hc.core5.net.URIAuthority;
 import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.apache.hc.core5.ssl.TrustStrategy;
+
+import java.io.File;
+import java.net.URL;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLContext;
 
 /**
  * Main program of the HTTP benchmark.
@@ -167,8 +166,8 @@ public class HttpBenchmark {
     public Results doExecute() throws Exception {
 
         final URL url = config.getUrl();
+        final long endTime = System.currentTimeMillis() + config.getTimeLimit()*1000;
         final HttpHost host = new HttpHost(url.getHost(), url.getPort(), url.getProtocol());
-
         final ThreadPoolExecutor workerPool = new ThreadPoolExecutor(
                 config.getThreads(), config.getThreads(), 5, TimeUnit.SECONDS,
             new LinkedBlockingQueue<Runnable>(),
@@ -226,6 +225,11 @@ public class HttpBenchmark {
             try {
                 Thread.sleep(1000);
             } catch (final InterruptedException ignore) {
+            }
+            if (config.getTimeLimit() != -1 && System.currentTimeMillis() > endTime) {
+                for (int i=0; i< workers.length; i++) {
+                    workers[i].setShutdownSignal();
+                }
             }
         }
 


### PR DESCRIPTION
This is to add an extra argument support for httpcore5-ab. Similar to 
> -t timelimit

parameter in [Apache ab](https://httpd.apache.org/docs/2.4/programs/ab.html)